### PR TITLE
Added __call__ method to tile sources

### DIFF
--- a/geoviews/element/geo.py
+++ b/geoviews/element/geo.py
@@ -175,6 +175,9 @@ class WMTS(_GeoFeature):
                             % (type(self).__name__, type(data).__name__) )
         super(WMTS, self).__init__(data, kdims=kdims, vdims=vdims, **params)
 
+    def __call__(self, *args, **kwargs):
+        return self.opts(*args, **kwargs)
+
 
 class Tiles(WMTS):
     """


### PR DESCRIPTION
Ensures that calling a tile source to clear the options continues to be allowed. This is useful since tile sources are often instantiated as singletons and these should be easy to reuse.