### PR TITLE
Adding css to make gallery fill all cells

### DIFF
--- a/doc/_static/custom.css
+++ b/doc/_static/custom.css
@@ -1,0 +1,3 @@
+.sphx-glr-thumbcontainer {
+    height: 210px;
+}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -21,6 +21,7 @@ html_theme_options = {
     'secondary_color': '#5f9df0',
     'second_nav': True,
     'footer': False,
+    'custom_css': 'custom.css',
 }
 
 _NAV =  (


### PR DESCRIPTION
This fixes the alignment issues here:

<img width="1001" alt="Screen Shot 2019-11-26 at 5 05 33 PM" src="https://user-images.githubusercontent.com/4806877/69676597-118ba480-106f-11ea-96e9-1a2ec7c17e52.png">
