### PR TITLE
Add codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: null
+        base: auto
+
+comment:
+  require_changes: yes


### PR DESCRIPTION
Mainly I'm triggering a commit to see if I've fixed codecov.io for hvplot.

Anyone know if we need this file? I copied it from panel.

(Same question for al lthe repos that are using codecov)