### PR TITLE
Do not propagate dataset property through projection operations

### DIFF
--- a/geoviews/operation/projection.py
+++ b/geoviews/operation/projection.py
@@ -36,6 +36,9 @@ class _project_operation(Operation):
     # Defines the types of elements supported by the operation
     supported_types = []
 
+    # Projection operations should not propagate dataset property
+    _propagate_dataset = False
+
     def _process(self, element, key=None):
         return element.map(self._process_element, self.supported_types)
 

--- a/geoviews/tests/testprojection.py
+++ b/geoviews/tests/testprojection.py
@@ -20,6 +20,10 @@ class TestProjection(ComparisonTestCase):
             [ 12960.,  17280.,  21600.,   4320.,   8640.]
         ]))
 
+        # Check dataset property did not propagate
+        self.assertNotEqual(proj.dataset, img.dataset)
+        self.assertEqual(proj.dataset.data, proj.data)
+
     def test_image_project_latlon_to_mercator(self):
         xs = np.linspace(72, 360, 5)
         ys = np.linspace(-60, 60, 3)
@@ -31,3 +35,7 @@ class TestProjection(ComparisonTestCase):
             [     0.,      0.,      0.,      0.,      0.],
             [ 12960.,  17280.,  21600.,   4320.,   8640.]
         ]))
+
+        # Check dataset property did not propagate
+        self.assertNotEqual(proj.dataset, img.dataset)
+        self.assertEqual(proj.dataset.data, proj.data)


### PR DESCRIPTION
This PR addresses an issue I ran into while trying to create a version of the glaciers demo using the HoloViews `link_selections` function.

In this demo, the kdims of a Dataset are projected using the GeoViews `project_points` operation.  This operation returns a new Dataset with kdims that have the same names, but their values are transformed into a new coordinate system.  Without this PR, the `.dataset` property of the resulting object will be inherited from the parent object. This breaks `link_selections` because you end up with fields in `obj.dataset` that have the same names as fields in `obj`, but their values are in different coordinate systems.

Along with https://github.com/holoviz/holoviews/pull/4137, This PR simply disables dataset propagation through projection operations.

An alternative to disabling propagation would be to require that projections introduce new field names, but I expect that this would be a significantly breaking change