### PR TITLE
Expanded and clarified annotator docs

### DIFF
--- a/examples/user_guide/Annotators.ipynb
+++ b/examples/user_guide/Annotators.ipynb
@@ -18,13 +18,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This notebook documents the usage and design of the `annotate` coordinator, which make it easy to draw, edit, and annotate polygon, polyline, rectangle, and point data on top of a map. The `annotate` function builds on Bokeh Drawing Tools connected to HoloViews drawing-tools streams, providing convenient access to the drawn data from Python. For a basic introduction to the ``annotate`` function see the [HoloViews Annotator user guide](https://holoviews.org/user_guide/Annotators.html). Importing GeoViews extends these annotators in a few important ways:\n",
+    "This notebook documents the usage and design of the `annotate` coordinator, which makes it easy to draw, edit, and annotate polygon, polyline, rectangle, and point data on top of a map or other plots. The `annotate` function builds on Bokeh Drawing Tools connected to HoloViews drawing-tools streams, providing convenient access to the drawn data from Python. For a detailed introduction to the ``annotate`` function, see the [HoloViews Annotator user guide](https://holoviews.org/user_guide/Annotators.html). This User Guide will focus on the additional functionality available for these annotators once GeoViews has been imported:\n",
     "\n",
-    "* The editable table will display coordinates as latitude and longitude pairs\n",
-    "* Additional checkpoint, restore and clear data tools are added\n",
-    "* The `gv.Path` annotator makes the distinction between feature nodes (at the start and end of a path) and regular nodes\n",
+    "* When used with GeoViews elements with a `crs`, the editable table will display coordinates as latitude and longitude pairs\n",
+    "* Additional checkpoint, restore, and clear-data tools are added\n",
+    "* The `gv.Path` annotator makes a distinction between feature nodes (at the start and end of a path) and regular nodes\n",
     "\n",
-    "In this guide we will demonstrate the usage of these annotators on a tile source to demonstrate how projections between Mercator and lat/lon coordinates are handled."
+    "In this guide we will demonstrate the usage of these annotators on a map tile source to demonstrate how projections between Mercator and lat/lon coordinates are handled."
    ]
   },
   {
@@ -33,7 +33,7 @@
    "source": [
     "## Annotating Points\n",
     "\n",
-    "When annotating a GeoViews elements it is assumed that the data is displayed in Web Mercator coordinates (as is the default when working with the Bokeh backend) but the coordinates may be supplied in any coordinate system. The table used to edit the coordinates will however always display longitudes and latitudes making it simpler to edit the coordinate values."
+    "When annotating a GeoViews element it is assumed that the data is displayed in Web Mercator coordinates (as is the default when working with the Bokeh backend) but the coordinates may be supplied in any coordinate system. Regardless of which coordinates are provided, the table used to edit the coordinates for a GeoViews annotator will always display longitudes and latitudes, making it simpler to edit the coordinate values."
    ]
   },
   {
@@ -80,7 +80,7 @@
    "source": [
     "## Annotating Rectangles\n",
     "\n",
-    "The GeoViews Rectangles annotator behaves much like the annotator in HoloViews but also projects the coordinates in the table to be more readable:"
+    "The GeoViews RectangleAnnotator behaves much like the RectangleAnnotator in HoloViews, but also projects the coordinates in the table to be more human-readable. To draw a rectangle, select the RectangleAnnotator tool in the Bokeh toolbar, then double click on one corner and drag to the location of the opposite corner:"
    ]
   },
   {
@@ -93,7 +93,7 @@
     "\n",
     "box_annotate = annotate.instance()\n",
     "\n",
-    "annotated = box_annotate(rectangles)\n",
+    "annotated = box_annotate(rectangles, name=\"Rectangles\")\n",
     "\n",
     "annotate.compose(tiles, annotated)"
    ]
@@ -113,7 +113,7 @@
    "source": [
     "## Annotating Paths\n",
     "\n",
-    "The path annotator behaves slightly differently to the one in HoloViews, when annotating a GeoViews Path a distinction is made between features nodes which describe the start and end point of a multi-line geometry and regular nodes which make up the interior nodes of the geometry. Additionally when attaching a new path on a regular node this will automatically split the existing path promoting the regular node to a feature node."
+    "The annotator for `gv.Path` objects behaves slightly differently from the one for HoloViews `hv.Path` objects, providing support for specifying the sort of boundary conditions typical in certain types of Earth-science modeling. Specifically, when annotating a GeoViews Path, a distinction is made between feature nodes, which describe the start and end point of a multi-line geometry, and regular nodes, which make up the interior nodes of the geometry. Attaching a new path to a regular node will split the existing path, automatically promoting the regular node to a feature node."
    ]
   },
   {
@@ -141,7 +141,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Just like the HoloViews version each path can be accessed using `iloc` or by using split which will return a list of Path elements representing each geometry:"
+    "Just like the HoloViews version, each path can be accessed using `iloc` or by using split, which will return a list of Path elements representing each geometry:"
    ]
   },
   {
@@ -160,7 +160,7 @@
     "## Annotating Polygons\n",
     "\n",
     "\n",
-    "The GeoViews Polygons annotator behaves much like the annotator in HoloViews but also projects the coordinates in the table to be more readable:"
+    "The GeoViews Polygons annotator behaves much like the PolyAnnotator in HoloViews but also projects the coordinates in the table to be more readable:"
    ]
   },
   {
@@ -211,7 +211,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Ready to merge, but the docs still need better and more comprehensive descriptions of how to use the Paths and Polygons annotators, which should be added before release.