### PR TITLE
Added conda update --all to conda install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,22 @@ objects.
 
 ## Installation
 
-You can install GeoViews and its dependencies using conda (to ensure you have a recent version of conda run `conda update -n root conda` first):
+If you want the latest GeoViews, you will need an up-to-date environment. Updating is never risk-free, but it is a good idea in general and the commands `conda list --revisions` and `conda install --revision N` can usually recover from updates gone awry.
 
+```
+conda update --all
+```
+
+You can then install GeoViews and all of its dependencies with the following:
+
+```
+conda install -c pyviz geoviews
+```
 
 Alternatively you can install the geoviews-core package, which
 only installs the minimal dependencies required to run geoviews:
 
 ```
-conda update --all
 conda install -c pyviz geoviews-core
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,12 +46,8 @@ objects.
 
 ## Installation
 
-You can install GeoViews and its dependencies using conda:
+You can install GeoViews and its dependencies using conda (to ensure you have a recent version of conda run `conda update -n root conda` first):
 
-```
-conda update --all
-conda install -c pyviz geoviews
-```
 
 Alternatively you can install the geoviews-core package, which
 only installs the minimal dependencies required to run geoviews:

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ objects.
 You can install GeoViews and its dependencies using conda:
 
 ```
+conda update --all
 conda install -c pyviz geoviews
 ```
 
@@ -56,6 +57,7 @@ Alternatively you can install the geoviews-core package, which
 only installs the minimal dependencies required to run geoviews:
 
 ```
+conda update --all
 conda install -c pyviz geoviews-core
 ```
 


### PR DESCRIPTION
I've just added `conda update --all` with minimal explanation here, as keeping the install instructions streamlined is a top priority and running an update before an install should be a familiar concept with a familiar risk profile in most cases. This particular form of the update command is recommended here: https://www.anaconda.com/keeping-anaconda-date/ and I've verified that it solves the issue here: https://github.com/holoviz/geoviews/issues/446 .