### PR TITLE
Standardize build procedures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,9 @@ env:
 stages:
   - test
   - name: website_release
-    if: tag =~ ^v(\d+|\.)*[^a-z]\d*$ OR tag = website AND NOT type = pull_request
+    if: tag =~ ^v(\d+|\.)+[^a-z]\d+$ OR tag = website
   - name: website_dev
-    if: (tag =~ ^v(\d+|\.)*[a-z]{1,2}\d*$) OR (tag = website_dev) OR ((commit_message =~ /\[doc-build\]/) and branch = master)
+    if: tag =~ ^v(\d+|\.)+[a-z]\d+$ OR tag = website_dev
   - name: conda_dev_package
     if: tag =~ ^v(\d+|\.)*[a-z]{1,2}\d*$
   - name: pip_dev_package

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ env:
 
 stages:
   - test
-  - name: docs
+  - name: website_release
     if: tag =~ ^v(\d+|\.)*[^a-z]\d*$ OR tag = website AND NOT type = pull_request
-  - name: docs_dev
+  - name: website_dev
     if: (tag =~ ^v(\d+|\.)*[a-z]{1,2}\d*$) OR (tag = website_dev) OR ((commit_message =~ /\[doc-build\]/) and branch = master)
   - name: conda_dev_package
     if: tag =~ ^v(\d+|\.)*[a-z]{1,2}\d*$
@@ -60,9 +60,9 @@ jobs:
 
     - &doc_build
       <<: *default
-      stage: docs
+      stage: website_release
       # not possible to run all examples to build website using only defaults (see setup.py)
-      env: DESC="docs" HV_DOC_HTML='true' CHANS_DEV="-c pyviz/label/dev -c conda-forge" PYTHON_VERSION="3.6"
+      env: DESC="website_release" HV_DOC_HTML='true' CHANS_DEV="-c pyviz/label/dev -c conda-forge" PYTHON_VERSION="3.6"
       install:
         - doit env_create $CHANS_DEV --python=$PYTHON_VERSION
         - source activate test-environment
@@ -87,7 +87,7 @@ jobs:
       after_success: true # don't upload coverage
 
     - <<: *doc_build
-      stage: docs_dev
+      stage: website_dev
       deploy:
         - provider: pages
           skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,9 @@ env:
 stages:
   - test
   - name: website_dev
-    if: (tag =~ ^v(\d+|\.)+[a-z]\d+$) OR (tag = website_dev) OR (commit_message =~ /^.*(website_dev).*$/)
+    if: (tag =~ ^v(\d+|\.)+[a|b|rc]\d+$) OR (tag = website_dev) OR (commit_message =~ /^.*(website_dev).*$/)
   - name: website_release
-    if: (tag =~ ^v(\d+|\.)+[^a-z]\d+$) OR (tag = website) OR (commit_message =~ /^.*(website_release).*$/)
+    if: (tag =~ ^v(\d+|\.)+\d+$) OR (tag = website_release) OR (commit_message =~ /^.*(website_release).*$/)
   - name: conda_dev_package
     if: tag =~ ^v(\d+|\.)*[a-z]{1,2}\d*$
   - name: pip_dev_package

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,10 @@ env:
 
 stages:
   - test
-  - name: website_release
-    if: tag =~ ^v(\d+|\.)+[^a-z]\d+$ OR tag = website
   - name: website_dev
-    if: tag =~ ^v(\d+|\.)+[a-z]\d+$ OR tag = website_dev
+    if: (tag =~ ^v(\d+|\.)+[a-z]\d+$) OR (tag = website_dev) OR (commit_message =~ /^.*(website_dev).*$/)
+  - name: website_release
+    if: (tag =~ ^v(\d+|\.)+[^a-z]\d+$) OR (tag = website) OR (commit_message =~ /^.*(website_release).*$/)
   - name: conda_dev_package
     if: tag =~ ^v(\d+|\.)*[a-z]{1,2}\d*$
   - name: pip_dev_package


### PR DESCRIPTION
This adds support for building dev and release websites with commit messages containing `website_dev` and `website_release` respectively, and building building from tags using `website_release` and `website_dev`, as well as tags of the format `v1.3.1a4` for dev, and `v1.3.1A4` for release.