### PR TITLE
Fix cartopy warnings and pin to cartopy=0.18

### DIFF
--- a/geoviews/plotting/mpl/__init__.py
+++ b/geoviews/plotting/mpl/__init__.py
@@ -137,17 +137,17 @@ class GeoPlot(ProjectionPlot, ElementPlot):
                 gl.xlocator = mticker.MaxNLocator(self.xticks)
 
             if self.xaxis in ['bottom', 'top-bare']:
-                gl.xlabels_top = False
+                gl.top_labels = False
             elif self.xaxis in ['top', 'bottom-bare']:
-                gl.xlabels_bottom = False
+                gl.bottom_labels = False
 
             if self.xformatter is None:
                 gl.xformatter = LONGITUDE_FORMATTER
             else:
                 gl.xformatter = wrap_formatter(self.xformatter)
         else:
-            gl.xlabels_top = False
-            gl.xlabels_bottom = False
+            gl.top_labels = False
+            gl.bottom_labels = False
 
 
         if self.yaxis and self.yaxis != 'bare':
@@ -160,17 +160,17 @@ class GeoPlot(ProjectionPlot, ElementPlot):
                 gl.ylocator = mticker.MaxNLocator(self.yticks)
 
             if self.yaxis in ['left', 'right-bare']:
-                gl.ylabels_right = False
+                gl.right_labels = False
             elif self.yaxis in ['right', 'left-bare']:
-                gl.ylabels_left = False
+                gl.left_labels = False
 
             if self.yformatter is None:
                 gl.yformatter = LATITUDE_FORMATTER
             else:
                 gl.yformatter = wrap_formatter(self.yformatter)
         else:
-            gl.ylabels_left = False
-            gl.ylabels_right = False
+            gl.left_labels = False
+            gl.right_labels = False
 
 
     def _finalize_axis(self, *args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ except:
 
 _required = [
     'bokeh >=2.1.0',
-    'cartopy >=0.17.0',
+    'cartopy >=0.18.0',
     'holoviews >=1.13.0',
     'numpy >=1.0',
     'param >=1.9.2',


### PR DESCRIPTION
For geoviews 1.8.2 I'm getting the following warnings:

```
lib/python3.7/site-packages/cartopy/mpl/gridliner.py:307: UserWarning: The .xlabels_top attribute is deprecated. Please use .top_labels to toggle visibility instead.
lib/python3.7/site-packages/cartopy/mpl/gridliner.py:343: UserWarning: The .ylabels_right attribute is deprecated. Please use .right_labels to toggle visibility instead.
```

As shown in https://scitools.org.uk/cartopy/docs/latest/_modules/cartopy/mpl/gridliner.html, various attribute names have been changed in cartopy, with properties left behind to map from the old names with that warning. That change was made 7 months ago (https://github.com/SciTools/cartopy/commit/f2ff5bda52394c51cd042534980d6cb59dac7531), so presumably we've been getting this warning since Cartopy 0.18.0 (released 6 months ago).

In this PR I've updated the names to avoid the warnings, but I also had to pin to cartopy=0.18.0, since that was a change in API. As far as I can tell we have to choose between supporting cartopy=0.17 (with warnings for 0.18), or 0.18 (with 0.17 failing).