### PR TITLE
Add missing _process_msg method to GeoPolyEditCallback

### DIFF
--- a/geoviews/plotting/bokeh/callbacks.py
+++ b/geoviews/plotting/bokeh/callbacks.py
@@ -255,6 +255,10 @@ class GeoPolyDrawCallback(PolyDrawCallback):
 
 class GeoPolyEditCallback(PolyEditCallback):
 
+    def _process_msg(self, msg):
+        msg = super(GeoPolyEditCallback, self)._process_msg(msg)
+        return project_poly(self, msg)
+
     def _update_cds_vdims(self, data):
         if isinstance(self.source, Shape):
             return


### PR DESCRIPTION
`GeoPolyEditCallback` was the only callback whose `_process_msg` was not defined. This is going to be useful for the GrabCut example (https://github.com/pyviz-topics/examples/pull/193).