### PR TITLE
Adapt to shapely 1.8.0 and 2.0

### DIFF
--- a/geoviews/data/geom_dict.py
+++ b/geoviews/data/geom_dict.py
@@ -136,7 +136,7 @@ class GeomDictInterface(DictInterface):
         if isinstance(geom, Polygon) and geom.interiors:
             return True
         elif isinstance(geom, MultiPolygon):
-            for g in geom:
+            for g in geom.geoms:
                 if isinstance(g, Polygon) and g.interiors:
                     return True
         return False
@@ -148,7 +148,7 @@ class GeomDictInterface(DictInterface):
         if isinstance(geom, Polygon):
             return [[[geom_to_array(h) for h in geom.interiors]]]
         elif isinstance(geom, MultiPolygon):
-            return [[[geom_to_array(h) for h in g.interiors] for g in geom]]
+            return [[[geom_to_array(h) for h in g.interiors] for g in geom.geoms]]
         return []
 
     @classmethod
@@ -276,9 +276,9 @@ class GeomDictInterface(DictInterface):
 
         if isinstance(geom, MultiPoint):
             if isscalar(rows) or isinstance(rows, slice):
-                geom = geom[rows]
+                geom = geom.geoms[rows]
             elif isinstance(rows, (set, list)):
-                geom = MultiPoint([geom[r] for r in rows])
+                geom = MultiPoint([geom.geoms[r] for r in rows])
         data['geometry'] = geom
         return data
 

--- a/geoviews/data/geopandas.py
+++ b/geoviews/data/geopandas.py
@@ -233,7 +233,7 @@ class GeoPandasInterface(MultiInterface):
                 index_mask = arr == k
                 if dataset.ndims == 1 and np.sum(index_mask) == 0:
                     data_index = np.argmin(np.abs(arr - k))
-                    mask = np.zeros(len(dataset), dtype=np.bool)
+                    mask = np.zeros(len(dataset), dtype=np.bool_)
                     mask[data_index] = True
                 else:
                     mask &= index_mask

--- a/geoviews/data/geopandas.py
+++ b/geoviews/data/geopandas.py
@@ -133,7 +133,7 @@ class GeoPandasInterface(MultiInterface):
             if isinstance(geom, Polygon) and geom.interiors:
                 return True
             elif isinstance(geom, MultiPolygon):
-                for g in geom:
+                for g in geom.geoms:
                     if isinstance(g, Polygon) and g.interiors:
                         return True
         return False
@@ -147,7 +147,7 @@ class GeoPandasInterface(MultiInterface):
             if isinstance(geom, Polygon) and geom.interiors:
                 holes.append([[geom_to_array(h) for h in geom.interiors]])
             elif isinstance(geom, MultiPolygon):
-                holes += [[[geom_to_array(h) for h in g.interiors] for g in geom]]
+                holes += [[[geom_to_array(h) for h in g.interiors] for g in geom.geoms]]
             else:
                 holes.append([[]])
         return holes
@@ -208,7 +208,7 @@ class GeoPandasInterface(MultiInterface):
 
     @classmethod
     def select_mask(cls, dataset, selection):
-        mask = np.ones(len(dataset.data), dtype=np.bool)
+        mask = np.ones(len(dataset.data), dtype=np.bool_)
         for dim, k in selection.items():
             if isinstance(k, tuple):
                 k = slice(*k)
@@ -427,10 +427,10 @@ class GeoPandasInterface(MultiInterface):
         count = 0
         new_geoms, indexes = [], []
         for i, geom in enumerate(geoms):
-            length = len(geom)
+            length = len(geom.geoms)
             if np.isscalar(rows):
                 if count <= rows < (count+length):
-                    new_geoms.append(geom[rows-count])
+                    new_geoms.append(geom.geoms[rows-count])
                     indexes.append(i)
                     break
             elif isinstance(rows, slice):
@@ -444,13 +444,13 @@ class GeoPandasInterface(MultiInterface):
                     dataset.param.warning(".iloc step slicing currently not supported for"
                                           "the multi-tabular data format.")
                 indexes.append(i)
-                new_geoms.append(geom[start:stop])
+                new_geoms.append(geom.geoms[start:stop])
             elif isinstance(rows, (list, set)):
                 sub_rows = [(r-count) for r in rows if count <= r < (count+length)]
                 if not sub_rows:
                     continue
                 indexes.append(i)
-                new_geoms.append(MultiPoint([geom[r] for r in sub_rows]))
+                new_geoms.append(MultiPoint([geom.geoms[r] for r in sub_rows]))
             count += length
 
         new = dataset.data.iloc[indexes].copy()

--- a/geoviews/operation/projection.py
+++ b/geoviews/operation/projection.py
@@ -275,7 +275,7 @@ class project_quadmesh(_project_operation):
                     np.isnan(edge_lengths)
                 )
             if np.any(to_mask):
-                mask = np.zeros(zs.shape, dtype=np.bool)
+                mask = np.zeros(zs.shape, dtype=np.bool_)
                 mask[:, 1:][to_mask] = True
                 mask[:, 2:][to_mask[:, :-1]] = True
                 mask[:, :-1][to_mask] = True

--- a/geoviews/tests/test_element.py
+++ b/geoviews/tests/test_element.py
@@ -23,28 +23,74 @@ class TestRectangles(ComparisonTestCase):
         rects = Rectangles([(0, 0, 1, 1)])
         geom = rects.geom()
         self.assertIsInstance(geom, Polygon)
-        self.assertEqual(np.array(geom.array_interface_base['data']),
-                         np.array([1, 0, 1, 1, 0, 1, 0, 0, 1, 0]))
+        self.assertEqual(
+            np.array(geom.exterior.coords),
+            np.array([
+                [1., 0.],
+                [1., 1.],
+                [0., 1.],
+                [0., 0.],
+                [1., 0.]
+            ])
+        )
 
     def test_multi_geom_conversion(self):
         rects = Rectangles([(0, 0, 1, 1), (3, 2, 2.5, 1.5)])
         geom = rects.geom()
         self.assertIsInstance(geom, MultiPolygon)
-        self.assertEqual(len(geom), 2)
-        self.assertEqual(np.array(geom[0].array_interface_base['data']),
-                         np.array([1, 0, 1, 1, 0, 1, 0, 0, 1, 0]))
-        self.assertEqual(np.array(geom[1].array_interface_base['data']),
-                         np.array([2.5, 2, 2.5, 1.5, 3, 1.5, 3, 2, 2.5, 2]))
+        self.assertEqual(len(geom.geoms), 2)
+        self.assertEqual(
+            np.array(geom.geoms[0].exterior.coords),
+            np.array([
+                [1., 0.],
+                [1., 1.],
+                [0., 1.],
+                [0., 0.],
+                [1., 0.]
+            ])   
+        )
+        self.assertEqual(
+            np.array(geom.geoms[1].exterior.coords),
+            np.array([
+                [2.5, 2],
+                [2.5, 1.5],
+                [3, 1.5],
+                [3, 2],
+                [2.5, 2]
+            ])
+        )
 
     def test_geom_union(self):
         rects = Rectangles([(0, 0, 1, 1), (1, 0, 2, 1)])
         geom = rects.geom(union=True)
         self.assertIsInstance(geom, Polygon)
-        array = np.array(geom.array_interface_base['data'])
+        array = np.array(geom.exterior.coords)
         try:
-            self.assertEqual(array, np.array([0, 0, 0, 1, 1, 1, 2, 1, 2, 0, 1, 0, 0, 0]))
+            self.assertEqual(
+                array,
+                np.array([
+                    [0, 0],
+                    [0, 1],
+                    [1, 1],
+                    [2, 1],
+                    [2, 0],
+                    [1, 0],
+                    [0, 0]
+                ])
+            )
         except Exception:
-            self.assertEqual(array, np.array([1, 0, 0, 0, 0, 1, 1, 1, 2, 1, 2, 0, 1, 0]))
+            self.assertEqual(
+                array,
+                np.array([
+                    [1, 0],
+                    [0, 0],
+                    [0, 1],
+                    [1, 1],
+                    [2, 1],
+                    [2, 0],
+                    [1, 0]
+                ])
+            )
 
 class TestPath(ComparisonTestCase):
 
@@ -56,19 +102,35 @@ class TestPath(ComparisonTestCase):
         path = Path([[(0, 0), (1, 1), (2, 0)]])
         geom = path.geom()
         self.assertIsInstance(geom, LineString)
-        self.assertEqual(np.array(geom.array_interface_base['data']),
-                         np.array([0, 0, 1, 1, 2, 0]))
+        self.assertEqual(
+            np.array(geom.coords),
+            np.array([
+                [0, 0],
+                [1, 1],
+                [2, 0]
+            ])
+        )
 
     def test_multi_geom_conversion(self):
         path = Path([[(0, 0), (1, 1), (2, 0)], [(3, 2), (2.5, 1.5)]])
         geom = path.geom()
         self.assertIsInstance(geom, MultiLineString)
-        self.assertEqual(len(geom), 2)
-        self.assertEqual(np.array(geom[0].array_interface_base['data']),
-                         np.array([0, 0, 1, 1, 2, 0]))
-        self.assertEqual(np.array(geom[1].array_interface_base['data']),
-                         np.array([3, 2, 2.5, 1.5]))
-
+        self.assertEqual(len(geom.geoms), 2)
+        self.assertEqual(
+            np.array(geom.geoms[0].coords),
+            np.array([
+                [0, 0],
+                [1, 1],
+                [2, 0]
+            ])
+        )            
+        self.assertEqual(
+            np.array(geom.geoms[1].coords),
+            np.array([
+                [3, 2],
+                [2.5, 1.5]
+            ])
+        )
 
 
 class TestPolygons(ComparisonTestCase):
@@ -81,20 +143,41 @@ class TestPolygons(ComparisonTestCase):
         path = Polygons([[(0, 0), (1, 1), (2, 0)]])
         geom = path.geom()
         self.assertIsInstance(geom, Polygon)
-        self.assertEqual(np.array(geom.array_interface_base['data']),
-                         np.array([0, 0, 1, 1, 2, 0, 0, 0]))
+        self.assertEqual(
+            np.array(geom.exterior.coords),
+            np.array([
+                [0, 0],
+                [1, 1],
+                [2, 0],
+                [0, 0]
+            ])
+        )
 
     def test_single_geom_with_hole_conversion(self):
         holes = [[((0.5, 0.2), (1, 0.8), (1.5, 0.2))]]
         path = Polygons([{'x': [0, 1, 2], 'y': [0, 1, 0], 'holes': holes}], ['x', 'y'])
         geom = path.geom()
         self.assertIsInstance(geom, Polygon)
-        self.assertEqual(np.array(geom.exterior.array_interface_base['data']),
-                         np.array([0, 0, 1, 1, 2, 0, 0, 0]))
+        self.assertEqual(
+            np.array(geom.exterior.coords),
+            np.array([
+                [0, 0],
+                [1, 1],
+                [2, 0],
+                [0, 0]
+            ])
+        )
         self.assertEqual(len(geom.interiors), 1)
         self.assertIsInstance(geom.interiors[0], LinearRing)
-        self.assertEqual(np.array(geom.interiors[0].array_interface_base['data']),
-                         np.array([0.5, 0.2, 1, 0.8, 1.5, 0.2, 0.5, 0.2]))
+        self.assertEqual(
+            np.array(geom.interiors[0].coords),
+            np.array([
+                [0.5, 0.2],
+                [1, 0.8],
+                [1.5, 0.2],
+                [0.5, 0.2]
+            ])
+        )
 
     def test_multi_geom_conversion(self):
         holes = [[((0.5, 0.2), (1, 0.8), (1.5, 0.2))]]
@@ -102,16 +185,37 @@ class TestPolygons(ComparisonTestCase):
                          {'x': [5, 6, 7], 'y': [2, 1, 2]}], ['x', 'y'])
         geom = path.geom()
         self.assertIsInstance(geom, MultiPolygon)
-        self.assertEqual(len(geom), 2)
-        self.assertEqual(np.array(geom[0].exterior.array_interface_base['data']),
-                         np.array([0, 0, 1, 1, 2, 0, 0, 0]))
-        self.assertEqual(len(geom[0].interiors), 1)
-        self.assertIsInstance(geom[0].interiors[0], LinearRing)
-        self.assertEqual(np.array(geom[0].interiors[0].array_interface_base['data']),
-                         np.array([0.5, 0.2, 1, 0.8, 1.5, 0.2, 0.5, 0.2]))
-        self.assertEqual(np.array(geom[1].exterior.array_interface_base['data']),
-                         np.array([5, 2, 6, 1, 7, 2, 5, 2]))
-        self.assertEqual(len(geom[1].interiors), 0)
+        self.assertEqual(len(geom.geoms), 2)
+        self.assertEqual(
+            np.array(geom.geoms[0].exterior.coords),
+            np.array([
+                [0, 0],
+                [1, 1],
+                [2, 0],
+                [0, 0]
+            ])
+        )
+        self.assertEqual(len(geom.geoms[0].interiors), 1)
+        self.assertIsInstance(geom.geoms[0].interiors[0], LinearRing)
+        self.assertEqual(
+            np.array(geom.geoms[0].interiors[0].coords),
+            np.array([
+                [0.5, 0.2],
+                [1, 0.8],
+                [1.5, 0.2],
+                [0.5, 0.2]
+            ])
+        )
+        self.assertEqual(
+            np.array(geom.geoms[1].exterior.coords),
+            np.array([
+                [5, 2],
+                [6, 1],
+                [7, 2],
+                [5, 2]
+            ])
+        )
+        self.assertEqual(len(geom.geoms[1].interiors), 0)
 
 
 
@@ -131,9 +235,9 @@ class TestPoints(ComparisonTestCase):
         points = Points([(0, 0), (1, 2.5)])
         geom = points.geom()
         self.assertIsInstance(geom, MultiPoint)
-        self.assertEqual(len(geom), 2)
-        self.assertEqual(np.column_stack(geom[0].xy), np.array([[0, 0]]))
-        self.assertEqual(np.column_stack(geom[1].xy), np.array([[1, 2.5]]))
+        self.assertEqual(len(geom.geoms), 2)
+        self.assertEqual(np.column_stack(geom.geoms[0].xy), np.array([[0, 0]]))
+        self.assertEqual(np.column_stack(geom.geoms[1].xy), np.array([[1, 2.5]]))
 
 
 class TestSegments(ComparisonTestCase):
@@ -146,15 +250,30 @@ class TestSegments(ComparisonTestCase):
         segs = Segments([(0, 0, 1, 1)])
         geom = segs.geom()
         self.assertIsInstance(geom, LineString)
-        self.assertEqual(np.array(geom.array_interface_base['data']),
-                         np.array([0, 0, 1, 1]))
+        self.assertEqual(
+            np.array(geom.coords),
+            np.array([
+                [0, 0],
+                [1, 1]
+            ])
+        )
 
     def test_multi_geom_conversion(self):
         segs = Segments([(0, 0, 1, 1), (1.5, 2, 3, 1)])
         geom = segs.geom()
         self.assertIsInstance(geom, MultiLineString)
-        self.assertEqual(len(geom), 2)
-        self.assertEqual(np.array(geom[0].array_interface_base['data']),
-                         np.array([0, 0, 1, 1]))
-        self.assertEqual(np.array(geom[1].array_interface_base['data']),
-                         np.array([1.5, 2, 3, 1]))
+        self.assertEqual(len(geom.geoms), 2)
+        self.assertEqual(
+            np.array(geom.geoms[0].coords),
+            np.array([
+                [0, 0],
+                [1, 1]
+            ])
+        )
+        self.assertEqual(
+            np.array(geom.geoms[1].coords),
+            np.array([[
+                1.5, 2],
+                [3, 1]
+            ])
+        )


### PR DESCRIPTION
Shapely 1.8.0 has recently been released and is unfortunately not compatible with geoviews. The most critical issue is that geoviews relied on the `array_interface_base`, which unfortunately contained a bug in shapely 1.8.0 (see this currently open PR https://github.com/Toblerity/Shapely/pull/1214) and forces users of geoviews to downgrade shapely.

shapely 1.8.0 prepares the next major version bump of shapely towards 2.0. They've release a *Migrating* guide which has been very useful (https://shapely.readthedocs.io/en/stable/migration.html). 