### PR TITLE
Update the css of links

### DIFF
--- a/doc/_static/custom.css
+++ b/doc/_static/custom.css
@@ -3,8 +3,9 @@
 }
 
 :root {
-    --pst-color-primary: #35835E;
-    --pst-color-link: #5f9df0;
+    --pst-color-primary: 47,47,47;
+    --pst-color-link: 56,123,178;
+    --pst-color-link-hover: 43,175,137;
 }
 
 .nav-link {


### PR DESCRIPTION
The links were not visible. They are now displayed in blue (like on hvplot) and in green when hovered (color picked from the logo). The headers are black, as on panel's site.