### PR TITLE
Replace LooseVersion by Version from packaging

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,6 @@ jobs:
         shell: bash -l {0} 
     env:
       DESC: "Python ${{ matrix.python-version }} tests"
-      HV_REQUIREMENTS: "unit_tests"
       PYTHON_VERSION: ${{ matrix.python-version }}
       CHANS_DEV: "-c pyviz/label/dev -c conda-forge -c nodefaults"
       CHANS: "-c pyviz -c conda-forge -c nodefaults"
@@ -61,7 +60,7 @@ jobs:
           eval "$(conda shell.bash hook)"
           conda activate test-environment
           conda list
-          doit develop_install ${{ env.CHANS_DEV}} -o examples -o recommended
+          doit develop_install ${{ env.CHANS_DEV}} -o tests -o examples -o recommended
 
       # Temporary step for Mac only due to develop_install failing (reason not yet found)
       - name: doit develop_install
@@ -70,7 +69,7 @@ jobs:
           eval "$(conda shell.bash hook)"
           conda activate test-environment
           conda list
-          doit develop_install ${{ env.CHANS_DEV}} -o examples -o recommended || echo "Keep going"
+          doit develop_install ${{ env.CHANS_DEV}} -o tests -o examples -o recommended || echo "Keep going"
           pip install --no-deps --no-build-isolation -e .
 
       - name: download test data

--- a/geoviews/plotting/bokeh/plot.py
+++ b/geoviews/plotting/bokeh/plot.py
@@ -20,7 +20,7 @@ class GeoPlot(ProjectionPlot, ElementPlot):
     """
 
     default_tools = param.List(default=['save', 'pan',
-                                        WheelZoomTool(zoom_on_axis=False}),
+                                        WheelZoomTool(zoom_on_axis=False),
                                         BoxZoomTool(match_aspect=True), 'reset'],
         doc="A list of plugin tools to use on the plot.")
 

--- a/geoviews/util.py
+++ b/geoviews/util.py
@@ -1,6 +1,5 @@
 from __future__ import division
 
-from distutils.version import LooseVersion
 import sys
 import warnings
 
@@ -13,6 +12,7 @@ from cartopy import crs as ccrs
 from cartopy.io.img_tiles import GoogleTiles, QuadtreeTiles
 from holoviews.element import Tiles
 from holoviews.core.util import basestring
+from packaging.version import Version
 from shapely.geometry.base import BaseMultipartGeometry
 from shapely.geometry import (
     MultiLineString, LineString, MultiPolygon, Polygon, LinearRing,
@@ -25,7 +25,7 @@ line_types = (MultiLineString, LineString)
 poly_types = (MultiPolygon, Polygon, LinearRing)
 
 
-shapely_version = LooseVersion(shapely.__version__)
+shapely_version = Version(shapely.__version__)
 
 
 def wrap_lons(lons, base, period):
@@ -339,7 +339,7 @@ def geom_to_arr(geom):
     # shapely 1.8.0 deprecated `array_interface` and 
     # unfortunately also introduced a bug in the `array_interface_base`
     # property which raised an error as soon as it was called.
-    if shapely_version < '1.8.0':
+    if shapely_version < Version('1.8.0'):
         if hasattr(geom, 'array_interface'):
             data = geom.array_interface()
             return np.array(data['data']).reshape(data['shape'])[:, :2]
@@ -362,7 +362,7 @@ def geom_length(geom):
     if hasattr(geom, 'exterior'):
         geom = geom.exterior
     # As of shapely 1.8.0: LineString, LinearRing (and GeometryCollection?)
-    if shapely_version < '1.8.0':
+    if shapely_version < Version('1.8.0'):
         if not geom.geom_type.startswith('Multi') and hasattr(geom, 'array_interface_base'):
             return len(geom.array_interface_base['data'])//2
     else:

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,8 @@ except:
 _required = [
     'bokeh >=2.4.0,<2.5',
     'cartopy >=0.18.0',
-    'holoviews >=1.14.2'
+    'holoviews >=1.14.2',
+    'packaging',
 ]
 
 _recommended = [


### PR DESCRIPTION
Required because geoviews is using `bokeh_version` from holoviews which since the last release is a `Version` object that can't be compared to a string. It means that currently geoviews cannot be imported if the latest holoviews is installed: https://discourse.holoviz.org/t/geoviews-import-error/3385