### PR TITLE
Compatibility with HoloViews 1.14.8

### DIFF
--- a/geoviews/plotting/bokeh/plot.py
+++ b/geoviews/plotting/bokeh/plot.py
@@ -9,7 +9,6 @@ from bokeh.models import MercatorTickFormatter, MercatorTicker
 from holoviews.core.dimension import Dimension
 from holoviews.core.util import dimension_sanitizer, basestring
 from holoviews.plotting.bokeh.element import ElementPlot, OverlayPlot as HvOverlayPlot
-from holoviews.plotting.bokeh.util import bokeh_version
 
 from ...element import is_geographic, _Element, Shape
 from ..plot import ProjectionPlot
@@ -21,8 +20,7 @@ class GeoPlot(ProjectionPlot, ElementPlot):
     """
 
     default_tools = param.List(default=['save', 'pan',
-                                        WheelZoomTool(**({} if bokeh_version < '0.12.16' else
-                                                         {'zoom_on_axis': False})),
+                                        WheelZoomTool(zoom_on_axis=False}),
                                         BoxZoomTool(match_aspect=True), 'reset'],
         doc="A list of plugin tools to use on the plot.")
 


### PR DESCRIPTION
We don't support older versions of bokeh anyway so this check was superfluous.