### PR TITLE
Fix handling of 3-channel RGB element

### DIFF
--- a/geoviews/element/geo.py
+++ b/geoviews/element/geo.py
@@ -420,7 +420,7 @@ class RGB(_Element, HvRGB):
 
     vdims = param.List(
         default=[Dimension('R', range=(0,1)), Dimension('G',range=(0,1)),
-                 Dimension('B', range=(0,1)), Dimension('A', range=(0,1))],
+                 Dimension('B', range=(0,1))],
         bounds=(3, 4), doc="""
         The dimension description of the data held in the matrix.
 


### PR DESCRIPTION
The `hv.RGB` constructor adds the alpha channel if needed so it should not be declared in the parameter definition.

Fixes https://github.com/holoviz/geoviews/issues/522