### PR TITLE
Fix the package builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -129,7 +129,7 @@ jobs:
         run: |
           eval "$(conda shell.bash hook)"
           conda activate test-environment
-          doit develop_install $CHANS_DEV -o build
+          doit develop_install $CHANS_DEV -o tests -o build
           doit pip_on_conda
       - name: pip build
         run: |

--- a/conda.recipe/recommended/meta.yaml
+++ b/conda.recipe/recommended/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - python {{ sdata['python_requires'] }}
     - geoviews-core ={{ sdata['version'] }}
     {% for dep in sdata['extras_require']['recommended'] %}
-    - {{ dep }}
+    - {{ dep if dep != 'geopandas' else 'geopandas-base'}}
     {% endfor %}
 
 about:


### PR DESCRIPTION
By:
* installing the tests extras during the pip build
* installing `geopandas-base` in the recommended recipe instead of `geopandas`. `geopandas-base` was declared in setup.py but it prevented users from installing the recommended extras from poetry (or pip?), since `geopandas-base` is available on conda only. Now the mapping option offered by pyctdev (located in setup.cfg) is used to  map `geopandas` (pip) to `geopandas-base` (conda). However this doesn't seem to be picked up when building the recipe.