### PR TITLE
Improve logic for geotype conversion

### DIFF
--- a/geoviews/operation/__init__.py
+++ b/geoviews/operation/__init__.py
@@ -25,7 +25,7 @@ def convert_to_geotype(element, crs=None):
     geotype = getattr(gv_element, type(element).__name__, None)
     if crs is None or geotype is None or isinstance(element, _Element):
         return element
-    return geotype(element, crs=crs)
+    return element.clone(new_type=geotype, crs=crs)
 
 
 def find_crs(op, element):


### PR DESCRIPTION
The previous approach did not correctly inherit parameters (like `kdims` and `vdims`) confusing the data interfaces.

Fixes https://github.com/holoviz/geoviews/issues/563