### PR TITLE
Replace basestring by str since Python 2 is no longer supported

### DIFF
--- a/geoviews/element/geo.py
+++ b/geoviews/element/geo.py
@@ -229,7 +229,7 @@ class WMTS(_GeoFeature):
             data = data.url
         elif WebMapTileService and isinstance(data, WebMapTileService):
             pass
-        elif not isinstance(data, util.basestring):
+        elif not isinstance(data, str):
             raise TypeError('%s data should be a tile service URL not a %s type.'
                             % (type(self).__name__, type(data).__name__) )
         super(WMTS, self).__init__(data, kdims=kdims, vdims=vdims, **params)

--- a/geoviews/plotting/bokeh/__init__.py
+++ b/geoviews/plotting/bokeh/__init__.py
@@ -45,7 +45,7 @@ class TilePlot(GeoPlot):
         return extents
 
     def get_data(self, element, ranges, style):
-        if not isinstance(element.data, util.basestring):
+        if not isinstance(element.data, str):
             SkipRendering("WMTS element data must be a URL string, "
                           "bokeh cannot render %r" % element.data)
         if '{Q}' in element.data.upper():

--- a/geoviews/plotting/bokeh/plot.py
+++ b/geoviews/plotting/bokeh/plot.py
@@ -7,7 +7,7 @@ from cartopy.crs import GOOGLE_MERCATOR, PlateCarree, Mercator
 from bokeh.models.tools import BoxZoomTool, WheelZoomTool
 from bokeh.models import MercatorTickFormatter, MercatorTicker
 from holoviews.core.dimension import Dimension
-from holoviews.core.util import dimension_sanitizer, basestring
+from holoviews.core.util import dimension_sanitizer
 from holoviews.plotting.bokeh.element import ElementPlot, OverlayPlot as HvOverlayPlot
 
 from ...element import is_geographic, _Element, Shape
@@ -126,7 +126,7 @@ class GeoPlot(ProjectionPlot, ElementPlot):
         except:
             CustomJSHover = None
         if (not self.geographic or None in (hover, CustomJSHover) or
-            isinstance(hover.tooltips, basestring) or self.projection is not GOOGLE_MERCATOR
+            isinstance(hover.tooltips, str) or self.projection is not GOOGLE_MERCATOR
             or hover.tooltips is None or 'hv_created' not in hover.tags):
             return
         element = self.current_frame

--- a/geoviews/plotting/mpl/__init__.py
+++ b/geoviews/plotting/mpl/__init__.py
@@ -483,7 +483,7 @@ class WMTSPlot(GeoPlot):
                   'filterrad', 'clims', 'norm']
 
     def get_data(self, element, ranges, style):
-        if isinstance(element.data, util.basestring):
+        if isinstance(element.data, str):
             if '{Q}' in element.data:
                 tile_source = QuadtreeTiles(url=element.data)
             else:

--- a/geoviews/util.py
+++ b/geoviews/util.py
@@ -11,7 +11,6 @@ import shapely.geometry as sgeom
 from cartopy import crs as ccrs
 from cartopy.io.img_tiles import GoogleTiles, QuadtreeTiles
 from holoviews.element import Tiles
-from holoviews.core.util import basestring
 from packaging.version import Version
 from shapely.geometry.base import BaseMultipartGeometry
 from shapely.geometry import (
@@ -461,7 +460,7 @@ def check_crs(crs):
     import pyproj
     if isinstance(crs, pyproj.Proj):
         out = crs
-    elif isinstance(crs, dict) or isinstance(crs, basestring):
+    elif isinstance(crs, dict) or isinstance(crs, str):
         try:
             out = pyproj.Proj(crs)
         except RuntimeError:
@@ -591,14 +590,14 @@ def process_crs(crs):
     if crs is None:
         return ccrs.PlateCarree()
 
-    if isinstance(crs, basestring) and crs.lower().startswith('epsg'):
+    if isinstance(crs, str) and crs.lower().startswith('epsg'):
         try:
             crs = ccrs.epsg(crs[5:].lstrip().rstrip())
         except:
             raise ValueError("Could not parse EPSG code as CRS, must be of the format 'EPSG: {code}.'")
     elif isinstance(crs, int):
         crs = ccrs.epsg(crs)
-    elif isinstance(crs, basestring) or is_pyproj(crs):
+    elif isinstance(crs, str) or is_pyproj(crs):
         try:
             crs = proj_to_cartopy(crs)
         except:


### PR DESCRIPTION
`basestring` will still be available in `holoviews.core.util` even after HoloViews drops Python 2, but this is still worth it.