### PR TITLE
Compatibility with HoloViews 1.15

### DIFF
--- a/geoviews/tests/data/test_geopandas.py
+++ b/geoviews/tests/data/test_geopandas.py
@@ -18,7 +18,7 @@ from holoviews.core.data import Dataset
 from holoviews.core.data.interface import DataError
 from holoviews.element import Polygons, Path, Points
 from holoviews.element.comparison import ComparisonTestCase
-from holoviews.tests.core.data.testmultiinterface import GeomTests
+from holoviews.tests.core.data.test_multiinterface import GeomTests
 
 from geoviews.data import GeoPandasInterface
 

--- a/geoviews/tests/data/test_iris.py
+++ b/geoviews/tests/data/test_iris.py
@@ -14,8 +14,8 @@ from geoviews.data.iris import coord_to_dimension
 from holoviews.core.spaces import HoloMap
 from holoviews.element import Image
 
-from holoviews.tests.core.data.testimageinterface import BaseImageElementInterfaceTests
-from holoviews.tests.core.data.testgridinterface import BaseGridInterfaceTests
+from holoviews.tests.core.data.test_imageinterface import BaseImageElementInterfaceTests
+from holoviews.tests.core.data.test_gridinterface import BaseGridInterfaceTests
 
 
 class IrisInterfaceTests(BaseGridInterfaceTests):

--- a/geoviews/tests/data/test_multigeometry.py
+++ b/geoviews/tests/data/test_multigeometry.py
@@ -10,7 +10,7 @@ from holoviews.core.data.interface import DataError
 from holoviews.core.util import pd
 from holoviews.element import Polygons, Path
 from holoviews.element.comparison import ComparisonTestCase
-from holoviews.tests.core.data.testmultiinterface import MultiBaseInterfaceTest
+from holoviews.tests.core.data.test_multiinterface import MultiBaseInterfaceTest
 
 try:
     from shapely import geometry as sgeom


### PR DESCRIPTION
GeoViews imports some test files from HoloViews which are renamed in 1.15, this PR fixes those imports.