### PR TITLE
Add implicit dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -98,6 +98,10 @@ _required = [
     'cartopy >=0.18.0',
     'holoviews >=1.14.2',
     'packaging',
+    'numpy',
+    'shapely',
+    'param',
+    'panel',
 ]
 
 _recommended = [


### PR DESCRIPTION
Found a few libraries that are imported in the code but not declared in the `setup.py` as required dependencies. I believe it's good practice to list them all as required dependencies, even if for instance `numpy` will in practice get installed because it's a dependency of `holoviews`.