### PR TITLE
Fix building with pip install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,5 @@ geoviews/.version
 .doit.db
 .pytest_cache
 
+node_modules/
+.bokeh

--- a/geoviews/package-lock.json
+++ b/geoviews/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "geoviews",
+  "name": "@holoviz/geoviews",
   "version": "1.9.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "geoviews",
+      "name": "@holoviz/geoviews",
       "version": "1.9.5",
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/geoviews/package-lock.json
+++ b/geoviews/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "geoviews",
       "version": "1.9.5",
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/geoviews/package.json
+++ b/geoviews/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "geoviews",
+  "name": "@holoviz/geoviews",
   "version": "1.9.5",
   "description": "Simple, concise geographical visualization in Python",
   "license": "BSD-3-Clause",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,4 @@ requires = [
     "pyviz_comms >=0.6.0",
     "setuptools",
 ]
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,5 +4,5 @@ requires = [
     "pyct >=0.4.4",
     "bokeh >=2.4.0,<2.5",
     "pyviz_comms >=0.6.0",
-    "setuptools"
+    "setuptools",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,5 +3,6 @@ requires = [
     "param >=1.9.0",
     "pyct >=0.4.4",
     "bokeh >=2.4.0,<2.5",
-    "pyviz_comms >=0.6.0"
+    "pyviz_comms >=0.6.0",
+    "setuptools"
 ]

--- a/setup.py
+++ b/setup.py
@@ -145,15 +145,6 @@ extras_require={
 
 extras_require['all'] = sorted(set(sum(extras_require.values(), [])))
 
-# until pyproject.toml/equivalent is widely supported; meanwhile
-# setup_requires doesn't work well with pip. Note: deliberately omitted from all.
-extras_require['build'] = [
-    'param >=1.9.2',
-    'pyct >=0.4.4',
-    'bokeh >=2.4,<2.5',
-    'pyviz_comms >=0.6.0'
-]
-
 
 ########################
 ### package metadata ###


### PR DESCRIPTION
I noticed that `python -m pip install .` did not work and raised the following traceback because `setuptools` was not present in `pyproject.toml`. 


<details>
  <summary>Traceback </summary>


``` python-traceback
ERROR: Exception:
Traceback (most recent call last):
  File "/home/shh/miniconda3/envs/holoviz/lib/python3.9/site-packages/pip/_internal/cli/base_command.py", line 167, in exc_logging_wrapper
    status = run_func(*args)
  File "/home/shh/miniconda3/envs/holoviz/lib/python3.9/site-packages/pip/_internal/cli/req_command.py", line 205, in wrapper
    return func(self, options, args)
  File "/home/shh/miniconda3/envs/holoviz/lib/python3.9/site-packages/pip/_internal/commands/install.py", line 341, in run
    requirement_set = resolver.resolve(
  File "/home/shh/miniconda3/envs/holoviz/lib/python3.9/site-packages/pip/_internal/resolution/resolvelib/resolver.py", line 75, in resolve
    collected = self.factory.collect_root_requirements(root_reqs)
  File "/home/shh/miniconda3/envs/holoviz/lib/python3.9/site-packages/pip/_internal/resolution/resolvelib/factory.py", line 506, in collect_root_requirements
    req = self._make_requirement_from_install_req(
  File "/home/shh/miniconda3/envs/holoviz/lib/python3.9/site-packages/pip/_internal/resolution/resolvelib/factory.py", line 468, in _make_requirement_from_install_req
    cand = self._make_candidate_from_link(
  File "/home/shh/miniconda3/envs/holoviz/lib/python3.9/site-packages/pip/_internal/resolution/resolvelib/factory.py", line 215, in _make_candidate_from_link
    self._link_candidate_cache[link] = LinkCandidate(
  File "/home/shh/miniconda3/envs/holoviz/lib/python3.9/site-packages/pip/_internal/resolution/resolvelib/candidates.py", line 291, in __init__
    super().__init__(
  File "/home/shh/miniconda3/envs/holoviz/lib/python3.9/site-packages/pip/_internal/resolution/resolvelib/candidates.py", line 161, in __init__
    self.dist = self._prepare()
  File "/home/shh/miniconda3/envs/holoviz/lib/python3.9/site-packages/pip/_internal/resolution/resolvelib/candidates.py", line 230, in _prepare
    dist = self._prepare_distribution()
  File "/home/shh/miniconda3/envs/holoviz/lib/python3.9/site-packages/pip/_internal/resolution/resolvelib/candidates.py", line 302, in _prepare_distribution
    return preparer.prepare_linked_requirement(self._ireq, parallel_builds=True)
  File "/home/shh/miniconda3/envs/holoviz/lib/python3.9/site-packages/pip/_internal/operations/prepare.py", line 428, in prepare_linked_requirement
    return self._prepare_linked_requirement(req, parallel_builds)
  File "/home/shh/miniconda3/envs/holoviz/lib/python3.9/site-packages/pip/_internal/operations/prepare.py", line 497, in _prepare_linked_requirement
    dist = _get_prepared_distribution(
  File "/home/shh/miniconda3/envs/holoviz/lib/python3.9/site-packages/pip/_internal/operations/prepare.py", line 58, in _get_prepared_distribution
    abstract_dist.prepare_distribution_metadata(
  File "/home/shh/miniconda3/envs/holoviz/lib/python3.9/site-packages/pip/_internal/distributions/sdist.py", line 48, in prepare_distribution_metadata
    self._install_build_reqs(finder)
  File "/home/shh/miniconda3/envs/holoviz/lib/python3.9/site-packages/pip/_internal/distributions/sdist.py", line 118, in _install_build_reqs
    build_reqs = self._get_build_requires_wheel()
  File "/home/shh/miniconda3/envs/holoviz/lib/python3.9/site-packages/pip/_internal/distributions/sdist.py", line 95, in _get_build_requires_wheel
    return backend.get_requires_for_build_wheel()
  File "/home/shh/miniconda3/envs/holoviz/lib/python3.9/site-packages/pip/_internal/utils/misc.py", line 685, in get_requires_for_build_wheel
    return super().get_requires_for_build_wheel(config_settings=cs)
  File "/home/shh/miniconda3/envs/holoviz/lib/python3.9/site-packages/pip/_vendor/pep517/wrappers.py", line 172, in get_requires_for_build_wheel
    return self._call_hook('get_requires_for_build_wheel', {
  File "/home/shh/miniconda3/envs/holoviz/lib/python3.9/site-packages/pip/_vendor/pep517/wrappers.py", line 332, in _call_hook
    raise BackendUnavailable(data.get('traceback', ''))
pip._vendor.pep517.wrappers.BackendUnavailable: Traceback (most recent call last):
  File "/home/shh/miniconda3/envs/holoviz/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 89, in _build_backend
    obj = import_module(mod_path)
  File "/home/shh/miniconda3/envs/holoviz/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 972, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 984, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'setuptools'
```

</details>

After adding it, I could successfully install `geoviews`, though I noticed that a name field was added to `package-lock.json`, so I added it to this commit. Other packages from holoviz seem to have a name like `@holoviz/geoviews` and not only `geoviews`. Should this also be done here?

At last I added `.bokeh` and `node_modules` to `.gitignore`. 
