### PR TITLE
Fix index outside bounds

### DIFF
--- a/geoviews/tests/test_util.py
+++ b/geoviews/tests/test_util.py
@@ -1,0 +1,19 @@
+import cartopy.crs as ccrs
+import pytest
+
+from geoviews.util import project_extents
+
+
+
+def test_outside_extents():
+    # extents outside bounds of map 32635, see https://epsg.io/32635
+    extents = (-2036817.4174174175, 577054.6546546547, -1801982.5825825825, 867745.3453453453)
+    dest_proj = ccrs.Mercator()
+    src_proj = ccrs.epsg(32635)
+
+    msg = (
+        "Could not project data from .+? projection to .+? projection\. "
+        "Ensure the coordinate reference system \(crs\) matches your data and the kdims\."
+    )
+    with pytest.raises(ValueError, match=msg):
+        project_extents(extents, src_proj, dest_proj)

--- a/geoviews/util.py
+++ b/geoviews/util.py
@@ -106,7 +106,7 @@ def project_extents(extents, src_proj, dest_proj, tol=1e-6):
                              'to %s projection. Ensure the coordinate '
                              'reference system (crs) matches your data '
                              'and the kdims.' %
-                             (src_name, dest_name))
+                             (src_name, dest_name)) from None
     else:
         geom_in_crs = boundary_poly.intersection(domain_in_src_proj)
     return geom_in_crs.bounds

--- a/geoviews/util.py
+++ b/geoviews/util.py
@@ -99,7 +99,7 @@ def project_extents(extents, src_proj, dest_proj, tol=1e-6):
             geom_in_src_proj = geom_clipped_to_dest_proj
         try:
             geom_in_crs = dest_proj.project_geometry(geom_in_src_proj, src_proj)
-        except ValueError:
+        except (ValueError, IndexError):
             src_name =type(src_proj).__name__
             dest_name =type(dest_proj).__name__
             raise ValueError('Could not project data from %s projection '


### PR DESCRIPTION
Fixes https://github.com/holoviz/hvplot/issues/738

It will still raise an error but is much more descriptive. 

Added `from None` to avoid `During handling of the above exception, another exception occurred` message.