### PR TITLE
Temporarily set NPM access to public

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -83,7 +83,7 @@ jobs:
         if: (github.event_name == 'push' && (contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
         run: |
           cd ./geoviews
-          npm publish --tag dev
+          npm publish --tag dev --access public
       - name: npm main deploy
         if: (github.event_name == 'push' && !(contains(steps.vars.outputs.tag, 'a') || contains(steps.vars.outputs.tag, 'b') || contains(steps.vars.outputs.tag, 'rc')))
         run: |


### PR DESCRIPTION
The geoviews javascript package is meant to be released under the `holoviz` scope now, however as this hasn't yet happened it needs to be declared as public as the default is private, and for that you'd have to pay npm. So this PR temporarily sets the access to public, temporarily as this just needs to be declared once. A following PR will revert this change.