### PR TITLE
Support numpy 1.24

### DIFF
--- a/geoviews/data/geom_dict.py
+++ b/geoviews/data/geom_dict.py
@@ -8,7 +8,7 @@ from holoviews.core.data.spatialpandas import to_geom_dict
 from holoviews.core.dimension import OrderedDict as cyODict, dimension_name
 from holoviews.core.util import isscalar
 
-from ..util import geom_types, geom_to_array, geom_length
+from ..util import asarray, geom_types, geom_to_array, geom_length
 
 
 class GeomDictInterface(DictInterface):
@@ -61,7 +61,7 @@ class GeomDictInterface(DictInterface):
         unpacked = []
         for d, vals in data.items():
             if isinstance(d, tuple):
-                vals = np.asarray(vals)
+                vals = asarray(vals)
                 if vals.shape == (0,):
                     for sd in d:
                         unpacked.append((sd, np.array([], dtype=vals.dtype)))
@@ -75,7 +75,7 @@ class GeomDictInterface(DictInterface):
                 unpacked.append((d, vals))
             else:
                 if not isscalar(vals):
-                    vals = np.asarray(vals)
+                    vals = asarray(vals)
                     if not vals.ndim == 1 and d in dimensions:
                         raise ValueError('DictInterface expects data for each column to be flat.')
                 unpacked.append((d, vals))
@@ -300,7 +300,7 @@ def geom_from_dict(geom, xdim, ydim, single_type, multi_type):
         Point, LineString, Polygon, MultiPoint, MultiPolygon, MultiLineString
     )
     if (xdim, ydim) in geom:
-        xs, ys = np.asarray(geom.pop((xdim, ydim))).T
+        xs, ys = asarray(geom.pop((xdim, ydim))).T
     elif xdim in geom and ydim in geom:
         xs, ys = geom.pop(xdim), geom.pop(ydim)
     else:

--- a/geoviews/data/geopandas.py
+++ b/geoviews/data/geopandas.py
@@ -15,7 +15,7 @@ from holoviews.core.data.spatialpandas import get_value_array
 from holoviews.core.dimension import dimension_name
 from holoviews.element import Path
 
-from ..util import geom_to_array, geom_types, geom_length
+from ..util import asarray, geom_to_array, geom_types, geom_length
 from .geom_dict import geom_from_dict
 
 
@@ -599,7 +599,7 @@ def from_multi(eltype, data, kdims, vdims):
     for d in data:
         types.append(type(d))
         if isinstance(d, dict):
-            d = {k: v if isscalar(v) else np.asarray(v) for k, v in d.items()}
+            d = {k: v if isscalar(v) else asarray(v) for k, v in d.items()}
             new_data.append(d)
             continue
         new_el = eltype(d, kdims, vdims)

--- a/geoviews/data/geopandas.py
+++ b/geoviews/data/geopandas.py
@@ -6,8 +6,9 @@ import warnings
 from collections import defaultdict
 
 import numpy as np
+import pandas as pd
 
-from holoviews.core.util import isscalar, unique_iterator, unique_array, pd
+from holoviews.core.util import isscalar, unique_iterator, unique_array
 from holoviews.core.data import Dataset, Interface, MultiInterface
 from holoviews.core.data.interface  import DataError
 from holoviews.core.data import PandasInterface

--- a/geoviews/util.py
+++ b/geoviews/util.py
@@ -776,3 +776,19 @@ def get_tile_rgb(tile_source, bbox, zoom_level, bbox_crs=ccrs.PlateCarree()):
     return RGB(
         rgb, bounds=(x0, y0, x1, y1), crs=ccrs.GOOGLE_MERCATOR, vdims=['R', 'G', 'B'],
     ).clone(datatype=['grid', 'xarray', 'iris'])[l:r, b:t]
+
+
+def asarray(v):
+    """Convert input to array
+
+    First it tries with a normal `np.asarray(v)` if this does not work
+    it tries with `np.asarray(v, dtype=object)`.
+
+    The ValueError raised is because of an inhomogeneous shape of the input,
+    which raises an error in numpy v1.24 and above.
+
+    """
+    try:
+        return np.asarray(v)
+    except ValueError:
+        return np.asarray(v, dtype=object)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,3 @@ requires = [
     "setuptools",
 ]
 build-backend = "setuptools.build_meta"
-
-[tool.pytest.ini_options]
-filterwarnings = [
-    # 2023-01-02: Numpy 1.24 warnings
-    "ignore:`.+?` is a deprecated alias for `.+?`.:DeprecationWarning:bokeh",  # https://github.com/bokeh/bokeh/pull/12690
-    "ignore:`.+?` is a deprecated alias for `.+?`.:DeprecationWarning:cupy",  # https://github.com/cupy/cupy/pull/7245
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,10 @@ requires = [
     "setuptools",
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    # 2023-01-02: Numpy 1.24 warnings
+    "ignore:`.+?` is a deprecated alias for `.+?`.:DeprecationWarning:bokeh",  # https://github.com/bokeh/bokeh/pull/12690
+    "ignore:`.+?` is a deprecated alias for `.+?`.:DeprecationWarning:cupy",  # https://github.com/cupy/cupy/pull/7245
+]

--- a/setup.py
+++ b/setup.py
@@ -115,6 +115,7 @@ _recommended = [
     'scipy',
     'shapely',
     'xarray',
+    'pooch',
 ]
 
 # Packages not working on python 3.11 becauase of numba

--- a/tox.ini
+++ b/tox.ini
@@ -67,6 +67,9 @@ nbsmoke_skip_run = .*Homepage\.ipynb$
                    .*gallery/.*/xarray_image\.ipynb$
                    .*gallery/.*/xarray_quadmesh\.ipynb$
                    .*gallery/.*/katrina_track\.ipynb$
+filterwarnings =
+    ignore:`.+?` is a deprecated alias for `.+?`.:DeprecationWarning:bokeh
+    ignore:`.+?` is a deprecated alias for `.+?`.:DeprecationWarning:cupy
 
 [flake8]
 include = *.py


### PR DESCRIPTION
With the release of numpy 1.24, the warning for inhomogeneous shape is now a ValueError. 

For Geoviews to work with the new numpy version, https://github.com/holoviz/holoviews/pull/5581 is also needed.  


![np_123](https://user-images.githubusercontent.com/19758978/210242810-032eeed7-16ec-45ee-aa6b-cd65621c37b7.png)

![np_124](https://user-images.githubusercontent.com/19758978/210242816-b89a25f7-61c3-4851-b258-228060926cea.png)

**TODO**
- [x] Need to check if examples can run
