### PR TITLE
Ensure doc build compiles GeoViews.js

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -30,6 +30,7 @@ jobs:
         shell: bash -l {0}
     env:
       DESC: "Documentation build"
+      SETUPTOOLS_ENABLE_FEATURES: "legacy-editable"
       MPLBACKEND: "Agg"
       MOZ_HEADLESS: 1
       DISPLAY: ":99.0"


### PR DESCRIPTION
Think this is what's causing the doc build to be run without geoviews.js