### PR TITLE
Add changelog for v1.9.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,41 @@
+Version 1.9.6
+=============
+
+Date: Jan 11, 2023
+
+This release contains a small number of bug fixes and compatibility for the latest releases of Numpy and Shapely. Many thanks to @pmav99, @philippjfr, @maximlt, and @Hoxbro.
+
+Bug fixes:
+- Fix regression and removing deprecation of annotators ([#583](https://github.com/holoviz/geoviews/pull/583))
+
+Compatibility:
+- Compatibility with Shapely 2.0 ([#570](https://github.com/holoviz/geoviews/pull/570), [#603](https://github.com/holoviz/geoviews/pull/603))
+- Compatibility with Numpy 1.24 ([#608](https://github.com/holoviz/geoviews/pull/608))
+- Compatibility with HoloViews 1.15 ([#572](https://github.com/holoviz/geoviews/pull/572), [#574](https://github.com/holoviz/geoviews/pull/574))
+- Compatibility with Python 3.11 ([#601](https://github.com/holoviz/geoviews/pull/601))
+
+Packaging:
+- Fix annotators not being packaging and therefore gave uncaught error in the console ([#610](https://github.com/holoviz/geoviews/pull/610))
+
+- Fix building with `pip install .` and update of packacges ([#575](https://github.com/holoviz/geoviews/pull/575), [#579](https://github.com/holoviz/geoviews/pull/579))
+
+- Setting NPM access to public and update `package.json` ([#585](https://github.com/holoviz/geoviews/pull/585), [#586](https://github.com/holoviz/geoviews/pull/586))
+
+Documentation:
+- Fix docs build ([#580](https://github.com/holoviz/geoviews/pull/580), [#588](https://github.com/holoviz/geoviews/pull/588))
+
+CI:
+- Various fixes and general maintenance of the CI ([#566](https://github.com/holoviz/geoviews/pull/566), [#567](https://github.com/holoviz/geoviews/pull/567), [#569](https://github.com/holoviz/geoviews/pull/569), [#573](https://github.com/holoviz/geoviews/pull/573), [#587](https://github.com/holoviz/geoviews/pull/587), [#591](https://github.com/holoviz/geoviews/pull/591), [#594](https://github.com/holoviz/geoviews/pull/594), [#595](https://github.com/holoviz/geoviews/pull/595), [#596](https://github.com/holoviz/geoviews/pull/596), [#600](https://github.com/holoviz/geoviews/pull/600), [#607](https://github.com/holoviz/geoviews/pull/607))
+
+- Adding pre-commit to CI ([#604](https://github.com/holoviz/geoviews/pull/604))
+
+Misc:
+- Rename master to main
+([#606](https://github.com/holoviz/geoviews/pull/606))
+- Remove Trove Classifier for Python 3.6
+([#565](https://github.com/holoviz/geoviews/pull/565))
+
+
 Version 1.9.5
 =============
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 Version 1.9.6
 =============
 
-Date: Jan 11, 2023
+Date: Jan 12, 2023
 
-This release contains a small number of bug fixes and compatibility for the latest releases of Numpy and Shapely. Many thanks to @pmav99, @philippjfr, @maximlt, and @Hoxbro.
+This release contains a small number of bug fixes and compatibility with the latest releases of Numpy and Shapely. Many thanks to @pmav99, @philippjfr, @maximlt, and @Hoxbro.
 
 Bug fixes:
-- Fix regression and removing deprecation of annotators ([#583](https://github.com/holoviz/geoviews/pull/583))
+- Fix regression and remove deprecation warnings for annotators ([#583](https://github.com/holoviz/geoviews/pull/583))
 
 Compatibility:
 - Compatibility with Shapely 2.0 ([#570](https://github.com/holoviz/geoviews/pull/570), [#603](https://github.com/holoviz/geoviews/pull/603))
@@ -15,25 +15,20 @@ Compatibility:
 - Compatibility with Python 3.11 ([#601](https://github.com/holoviz/geoviews/pull/601))
 
 Packaging:
-- Fix annotators not being packaging and therefore gave uncaught error in the console ([#610](https://github.com/holoviz/geoviews/pull/610))
+- Fix TypeScript files not being packaged and therefore gave an uncaught error in the console for annotators ([#610](https://github.com/holoviz/geoviews/pull/610))
 
-- Fix building with `pip install .` and update of packacges ([#575](https://github.com/holoviz/geoviews/pull/575), [#579](https://github.com/holoviz/geoviews/pull/579))
+- Fix building with `pip install .` and update of packages ([#575](https://github.com/holoviz/geoviews/pull/575), [#579](https://github.com/holoviz/geoviews/pull/579))
 
 - Setting NPM access to public and update `package.json` ([#585](https://github.com/holoviz/geoviews/pull/585), [#586](https://github.com/holoviz/geoviews/pull/586))
 
 Documentation:
-- Fix docs build ([#580](https://github.com/holoviz/geoviews/pull/580), [#588](https://github.com/holoviz/geoviews/pull/588))
+- Fix docs build ([#580](https://github.com/holoviz/geoviews/pull/580), [#588](https://github.com/holoviz/geoviews/pull/588), [#611](https://github.com/holoviz/geoviews/pull/611), [#612](https://github.com/holoviz/geoviews/pull/612))
 
-CI:
-- Various fixes and general maintenance of the CI ([#566](https://github.com/holoviz/geoviews/pull/566), [#567](https://github.com/holoviz/geoviews/pull/567), [#569](https://github.com/holoviz/geoviews/pull/569), [#573](https://github.com/holoviz/geoviews/pull/573), [#587](https://github.com/holoviz/geoviews/pull/587), [#591](https://github.com/holoviz/geoviews/pull/591), [#594](https://github.com/holoviz/geoviews/pull/594), [#595](https://github.com/holoviz/geoviews/pull/595), [#596](https://github.com/holoviz/geoviews/pull/596), [#600](https://github.com/holoviz/geoviews/pull/600), [#607](https://github.com/holoviz/geoviews/pull/607))
-
+Maintenance:
 - Adding pre-commit to CI ([#604](https://github.com/holoviz/geoviews/pull/604))
-
-Misc:
-- Rename master to main
-([#606](https://github.com/holoviz/geoviews/pull/606))
-- Remove Trove Classifier for Python 3.6
-([#565](https://github.com/holoviz/geoviews/pull/565))
+- Rename master to main ([#606](https://github.com/holoviz/geoviews/pull/606))
+- Remove Trove Classifier for Python 3.6 ([#565](https://github.com/holoviz/geoviews/pull/565))
+- Various fixes and general maintenance of the CI ([#566](https://github.com/holoviz/geoviews/pull/566), [#567](https://github.com/holoviz/geoviews/pull/567), [#569](https://github.com/holoviz/geoviews/pull/569), [#573](https://github.com/holoviz/geoviews/pull/573), [#587](https://github.com/holoviz/geoviews/pull/587), [#591](https://github.com/holoviz/geoviews/pull/591), [#594](https://github.com/holoviz/geoviews/pull/594), [#595](https://github.com/holoviz/geoviews/pull/595), [#596](https://github.com/holoviz/geoviews/pull/596), [#600](https://github.com/holoviz/geoviews/pull/600), [#607](https://github.com/holoviz/geoviews/pull/607))
 
 
 Version 1.9.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,32 +1,35 @@
 Version 1.9.6
 =============
 
-Date: Jan 12, 2023
+Date: Jan 17, 2023
 
 This release contains a small number of bug fixes and compatibility with the latest releases of Numpy and Shapely. Many thanks to @pmav99, @philippjfr, @maximlt, and @Hoxbro.
 
 Bug fixes:
-- Fix regression and remove deprecation warnings for annotators ([#583](https://github.com/holoviz/geoviews/pull/583))
+
+- Fix regression and remove deprecation warnings for `gv.annotators` ([#583](https://github.com/holoviz/geoviews/pull/583))
 
 Compatibility:
+
 - Compatibility with Shapely 2.0 ([#570](https://github.com/holoviz/geoviews/pull/570), [#603](https://github.com/holoviz/geoviews/pull/603))
 - Compatibility with Numpy 1.24 ([#608](https://github.com/holoviz/geoviews/pull/608))
 - Compatibility with HoloViews 1.15 ([#572](https://github.com/holoviz/geoviews/pull/572), [#574](https://github.com/holoviz/geoviews/pull/574))
 - Compatibility with Python 3.11 ([#601](https://github.com/holoviz/geoviews/pull/601))
 
 Packaging:
-- Fix TypeScript files not being packaged and therefore gave an uncaught error in the console for annotators ([#610](https://github.com/holoviz/geoviews/pull/610))
 
+- Fix TypeScript files not being packaged and therefore gave an uncaught error in the console for `gv.annotators` ([#610](https://github.com/holoviz/geoviews/pull/610))
 - Fix building with `pip install .` and update of packages ([#575](https://github.com/holoviz/geoviews/pull/575), [#579](https://github.com/holoviz/geoviews/pull/579))
-
 - Setting NPM access to public and update `package.json` ([#585](https://github.com/holoviz/geoviews/pull/585), [#586](https://github.com/holoviz/geoviews/pull/586))
 
 Documentation:
+
 - Fix docs build ([#580](https://github.com/holoviz/geoviews/pull/580), [#588](https://github.com/holoviz/geoviews/pull/588), [#611](https://github.com/holoviz/geoviews/pull/611), [#612](https://github.com/holoviz/geoviews/pull/612))
 
 Maintenance:
+
 - Adding pre-commit to CI ([#604](https://github.com/holoviz/geoviews/pull/604))
-- Rename master to main ([#606](https://github.com/holoviz/geoviews/pull/606))
+- Renamed `master` branch to `main` ([#606](https://github.com/holoviz/geoviews/pull/606))
 - Remove Trove Classifier for Python 3.6 ([#565](https://github.com/holoviz/geoviews/pull/565))
 - Various fixes and general maintenance of the CI ([#566](https://github.com/holoviz/geoviews/pull/566), [#567](https://github.com/holoviz/geoviews/pull/567), [#569](https://github.com/holoviz/geoviews/pull/569), [#573](https://github.com/holoviz/geoviews/pull/573), [#587](https://github.com/holoviz/geoviews/pull/587), [#591](https://github.com/holoviz/geoviews/pull/591), [#594](https://github.com/holoviz/geoviews/pull/594), [#595](https://github.com/holoviz/geoviews/pull/595), [#596](https://github.com/holoviz/geoviews/pull/596), [#600](https://github.com/holoviz/geoviews/pull/600), [#607](https://github.com/holoviz/geoviews/pull/607))
 

--- a/doc/releases.rst
+++ b/doc/releases.rst
@@ -1,6 +1,75 @@
 Releases
 ========
 
+Version 1.9.6
+-------------
+
+Date: Jan 17, 2023
+
+This release contains a small number of bug fixes and compatibility with
+the latest releases of Numpy and Shapely. Many thanks to @pmav99,
+@philippjfr, @maximlt, and @Hoxbro.
+
+Bug fixes:
+
+-  Fix regression and remove deprecation warnings for ``gv.annotators``
+   (`#583 <https://github.com/holoviz/geoviews/pull/583>`__)
+
+Compatibility:
+
+-  Compatibility with Shapely 2.0
+   (`#570 <https://github.com/holoviz/geoviews/pull/570>`__,
+   `#603 <https://github.com/holoviz/geoviews/pull/603>`__)
+-  Compatibility with Numpy 1.24
+   (`#608 <https://github.com/holoviz/geoviews/pull/608>`__)
+-  Compatibility with HoloViews 1.15
+   (`#572 <https://github.com/holoviz/geoviews/pull/572>`__,
+   `#574 <https://github.com/holoviz/geoviews/pull/574>`__)
+-  Compatibility with Python 3.11
+   (`#601 <https://github.com/holoviz/geoviews/pull/601>`__)
+
+Packaging:
+
+-  Fix TypeScript files not being packaged and therefore gave an
+   uncaught error in the console for ``gv.annotators``
+   (`#610 <https://github.com/holoviz/geoviews/pull/610>`__)
+-  Fix building with ``pip install .`` and update of packages
+   (`#575 <https://github.com/holoviz/geoviews/pull/575>`__,
+   `#579 <https://github.com/holoviz/geoviews/pull/579>`__)
+-  Setting NPM access to public and update ``package.json``
+   (`#585 <https://github.com/holoviz/geoviews/pull/585>`__,
+   `#586 <https://github.com/holoviz/geoviews/pull/586>`__)
+
+Documentation:
+
+-  Fix docs build
+   (`#580 <https://github.com/holoviz/geoviews/pull/580>`__,
+   `#588 <https://github.com/holoviz/geoviews/pull/588>`__,
+   `#611 <https://github.com/holoviz/geoviews/pull/611>`__,
+   `#612 <https://github.com/holoviz/geoviews/pull/612>`__)
+
+Maintenance:
+
+-  Adding pre-commit to CI
+   (`#604 <https://github.com/holoviz/geoviews/pull/604>`__)
+-  Renamed ``master`` branch to ``main``
+   (`#606 <https://github.com/holoviz/geoviews/pull/606>`__)
+-  Remove Trove Classifier for Python 3.6
+   (`#565 <https://github.com/holoviz/geoviews/pull/565>`__)
+-  Various fixes and general maintenance of the CI
+   (`#566 <https://github.com/holoviz/geoviews/pull/566>`__,
+   `#567 <https://github.com/holoviz/geoviews/pull/567>`__,
+   `#569 <https://github.com/holoviz/geoviews/pull/569>`__,
+   `#573 <https://github.com/holoviz/geoviews/pull/573>`__,
+   `#587 <https://github.com/holoviz/geoviews/pull/587>`__,
+   `#591 <https://github.com/holoviz/geoviews/pull/591>`__,
+   `#594 <https://github.com/holoviz/geoviews/pull/594>`__,
+   `#595 <https://github.com/holoviz/geoviews/pull/595>`__,
+   `#596 <https://github.com/holoviz/geoviews/pull/596>`__,
+   `#600 <https://github.com/holoviz/geoviews/pull/600>`__,
+   `#607 <https://github.com/holoviz/geoviews/pull/607>`__)
+
+
 Version 1.9.5
 -------------
 

--- a/geoviews/package-lock.json
+++ b/geoviews/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@holoviz/geoviews",
-  "version": "1.9.6-a.4",
+  "version": "1.9.6-a.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@holoviz/geoviews",
-      "version": "1.9.6-a.4",
+      "version": "1.9.6-a.5",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@bokeh/bokehjs": "^2.4.2"

--- a/geoviews/package.json
+++ b/geoviews/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holoviz/geoviews",
-  "version": "1.9.6-a.4",
+  "version": "1.9.6-a.5",
   "description": "Simple, concise geographical visualization in Python",
   "license": "BSD-3-Clause",
   "repository": {


### PR DESCRIPTION
To be merged after #583

And need to be exported to `docs/release.rst`. 

Note to self: need to update package.json before the tag.