### PR TITLE
Param 2: allow `Dataset` to have any number of `kdims`

### DIFF
--- a/geoviews/element/geo.py
+++ b/geoviews/element/geo.py
@@ -253,6 +253,7 @@ class Dataset(_Element, HvDataset):
     """
 
     kdims = param.List(default=[Dimension('Longitude'), Dimension('Latitude')],
+                       bounds=(0, None),
                        constant=True)
 
     group = param.String(default='Dataset')


### PR DESCRIPTION
Fixes https://github.com/holoviz/geoviews/issues/624, in preparation of Param 2.

`kdims.bounds` was inherited from `_Element` with a value of `(2, 2)`, which appeared not to be valid for `Dataset`. Running the notebooks pointed out in the issue, I saw that `Dataset` could have more `kdims` than 2. I was also slightly surprised to see that it could have less than 2, I got an error where `kdims` was just `[Dimension('time')]`. I decided to let `kdims` accept any number of dimensions, i.e. `bounds=(0, None)`, as this anyway the default value in Param 1.