### PR TITLE
Add `pyproj` to the runtime dependencies

### DIFF
--- a/geoviews/util.py
+++ b/geoviews/util.py
@@ -1,6 +1,5 @@
 from __future__ import division
 
-import sys
 import warnings
 
 import numpy as np

--- a/geoviews/util.py
+++ b/geoviews/util.py
@@ -11,7 +11,6 @@ from cartopy import crs as ccrs
 from cartopy.io.img_tiles import GoogleTiles, QuadtreeTiles
 from holoviews.element import Tiles
 from packaging.version import Version
-from pyproj import Transformer
 from shapely.geometry import (
     LinearRing, LineString, MultiLineString, MultiPoint,
     MultiPolygon, Point, Polygon, box
@@ -797,6 +796,8 @@ def asarray(v):
 
 
 def transform_shapely(geom, crs_from, crs_to):
+    from pyproj import Transformer
+
     if isinstance(crs_to, str):
         crs_to = ccrs.CRS(crs_to)
     if isinstance(crs_from, str):

--- a/geoviews/util.py
+++ b/geoviews/util.py
@@ -567,8 +567,6 @@ def proj_to_cartopy(proj):
 
 
 def is_pyproj(crs):
-    if 'pyproj' not in sys.modules:
-        return False
     import pyproj
     return isinstance(crs, pyproj.Proj)
 

--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,7 @@ _required = [
     'shapely',
     'param',
     'panel <1.0.0',
+    'pyproj',
 ]
 
 _recommended = [


### PR DESCRIPTION
Fixes https://github.com/holoviz/geoviews/issues/621

But also always lazy load `pyproj`, not to increase the import time of geoviews/hvplot which is already long enough.

The conda-forge recipe will have to be updated accordingly.