### PR TITLE
Code maintenance

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: trailing-whitespace
         exclude: \.svg$
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.261
+    rev: v0.0.263
     hooks:
       - id: ruff
         args: [geoviews]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,11 @@
 # This is the configuration for pre-commit, a local framework for managing pre-commit hooks
 #   Check out the docs at: https://pre-commit.com/
 
+exclude: (\.min\.js$|\.svg$|\.html$)
 default_stages: [commit]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.4.0
     hooks:
       - id: check-builtin-literals
       - id: check-case-conflict
@@ -13,16 +14,15 @@ repos:
       - id: check-toml
       - id: detect-private-key
       - id: end-of-file-fixer
-        exclude: (\.min\.js$|\.svg$)
       - id: trailing-whitespace
         exclude: \.svg$
-  - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.261
     hooks:
-      - id: flake8 # See 'setup.cfg' for args
+      - id: ruff
         args: [geoviews]
         files: geoviews/
   - repo: https://github.com/hoxbro/clean_notebook
-    rev: 0.1.5
+    rev: v0.1.9
     hooks:
       - id: clean-notebook

--- a/geoviews/__init__.py
+++ b/geoviews/__init__.py
@@ -4,11 +4,7 @@ from holoviews import (extension, help, opts, output, renderer, Store, # noqa (A
                        Cycle, Palette, Overlay, Layout, NdOverlay, NdLayout,
                        HoloMap, DynamicMap, GridSpace, Dimension, dim)
 
-try:
-    # Only available in HoloViews >=1.11
-    from holoviews import render, save # noqa (API import)
-except:
-    pass
+from holoviews import render, save # noqa (API import)
 
 from .annotators import annotate # noqa (API import)
 from .element import ( # noqa (API import)

--- a/geoviews/annotators.py
+++ b/geoviews/annotators.py
@@ -4,7 +4,7 @@ import cartopy.crs as ccrs
 
 from holoviews.annotators import (
     annotate, Annotator, PathAnnotator, PolyAnnotator, PointAnnotator,
-    RectangleAnnotator  # noqa
+    RectangleAnnotator
 )
 from holoviews.plotting.links import DataLink, VertexTableLink as hvVertexTableLink
 from panel.util import param_name

--- a/geoviews/data/__init__.py
+++ b/geoviews/data/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from .geom_dict import GeomDictInterface # noqa (API import)
 from .geopandas import GeoPandasInterface # noqa (API import)
 from .iris import CubeInterface # noqa (API import)

--- a/geoviews/data/geom_dict.py
+++ b/geoviews/data/geom_dict.py
@@ -245,9 +245,10 @@ class GeomDictInterface(DictInterface):
         elif isinstance(xsel, tuple):
             x0, x1 = xsel
         else:
-            raise ValueError("Only slicing is supported on geometries, %s "
-                             "selection is of type %s."
-                             % (xdim, type(xsel).__name__))
+            raise ValueError(
+                f"Only slicing is supported on geometries, {xdim} "
+                f"selection is of type {type(xsel).__name__}."
+            )
 
         if ysel is None:
             y0, y1 = cls.range(dataset, ydim)
@@ -256,9 +257,10 @@ class GeomDictInterface(DictInterface):
         elif isinstance(ysel, tuple):
             y0, y1 = ysel
         else:
-            raise ValueError("Only slicing is supported on geometries, %s "
-                             "selection is of type %s."
-                             % (ydim, type(ysel).__name__))
+            raise ValueError(
+                f"Only slicing is supported on geometries, {ydim} "
+                f"selection is of type {type(ysel).__name__}."
+            )
 
         bounds = box(x0, y0, x1, y1)
         geom = dataset.data['geometry']

--- a/geoviews/data/geom_dict.py
+++ b/geoviews/data/geom_dict.py
@@ -5,7 +5,7 @@ import numpy as np
 from holoviews.core.data import Interface, DictInterface, MultiInterface
 from holoviews.core.data.interface import DataError
 from holoviews.core.data.spatialpandas import to_geom_dict
-from holoviews.core.dimension import OrderedDict as cyODict, dimension_name
+from holoviews.core.dimension import dimension_name
 from holoviews.core.util import isscalar
 
 from ..util import asarray, geom_types, geom_to_array, geom_length
@@ -25,7 +25,7 @@ class GeomDictInterface(DictInterface):
 
     @classmethod
     def init(cls, eltype, data, kdims, vdims):
-        odict_types = (OrderedDict, cyODict)
+        odict_types = (OrderedDict,)
         if kdims is None:
             kdims = eltype.kdims
         if vdims is None:

--- a/geoviews/data/geopandas.py
+++ b/geoviews/data/geopandas.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import sys
 import warnings
 

--- a/geoviews/data/geopandas.py
+++ b/geoviews/data/geopandas.py
@@ -98,7 +98,7 @@ class GeoPandasInterface(PandasAPI, MultiInterface):
 
         try:
             shp_types = {gt[5:] if 'Multi' in gt else gt for gt in data.geom_type}
-        except:
+        except Exception:
             shp_types = []
         if len(shp_types) > 1:
             raise DataError('The GeopandasInterface can only read dataframes which '

--- a/geoviews/data/geopandas.py
+++ b/geoviews/data/geopandas.py
@@ -189,9 +189,10 @@ class GeoPandasInterface(PandasAPI, MultiInterface):
         elif isinstance(xsel, tuple):
             x0, x1 = xsel
         else:
-            raise ValueError("Only slicing is supported on geometries, %s "
-                             "selection is of type %s."
-                             % (xdim, type(xsel).__name__))
+            raise ValueError(
+                f"Only slicing is supported on geometries, {xdim} "
+                f"selection is of type {type(xsel).__name__}."
+            )
 
         if ysel is None:
             y0, y1 = cls.range(dataset, ydim)
@@ -200,9 +201,10 @@ class GeoPandasInterface(PandasAPI, MultiInterface):
         elif isinstance(ysel, tuple):
             y0, y1 = ysel
         else:
-            raise ValueError("Only slicing is supported on geometries, %s "
-                             "selection is of type %s."
-                             % (ydim, type(ysel).__name__))
+            raise ValueError(
+                f"Only slicing is supported on geometries, {ydim} "
+                f"selection is of type {type(ysel).__name__}."
+            )
 
         bounds = box(x0, y0, x1, y1)
         col = cls.geo_column(dataset.data)

--- a/geoviews/data/iris.py
+++ b/geoviews/data/iris.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import sys
 import datetime
 from itertools import product

--- a/geoviews/data/iris.py
+++ b/geoviews/data/iris.py
@@ -116,7 +116,7 @@ class CubeInterface(GridInterface):
             try:
                 data = iris.cube.Cube(value_array, long_name=vdim.name,
                                       dim_coords_and_dims=coords)
-            except:
+            except Exception:
                 pass
             if not isinstance(data, iris.cube.Cube):
                 raise TypeError('Data must be be an iris Cube type.')

--- a/geoviews/element/__init__.py
+++ b/geoviews/element/__init__.py
@@ -36,7 +36,7 @@ class GeoConversion(ElementConversion):
             else:
                 args = (Dataset,)
                 kwargs['kdims'] = []
-        converted = super(GeoConversion, self).__call__(*args, **kwargs)
+        converted = super().__call__(*args, **kwargs)
         if is_gpd:
             if kdims is None: kdims = group_type.kdims
             converted = converted.map(lambda x: x.clone(kdims=kdims, new_type=group_type), Dataset)

--- a/geoviews/element/comparison.py
+++ b/geoviews/element/comparison.py
@@ -8,7 +8,7 @@ class Comparison(HvComparison):
 
     @classmethod
     def register(cls):
-        super(Comparison, cls).register()
+        super().register()
         cls.equality_type_funcs[Image] = cls.compare_dataset
         cls.equality_type_funcs[Points] = cls.compare_dataset
         cls.equality_type_funcs[LineContours] = cls.compare_dataset

--- a/geoviews/element/geo.py
+++ b/geoviews/element/geo.py
@@ -1,6 +1,7 @@
 import param
 import numpy as np
 
+from bokeh.models import MercatorTileSource
 from cartopy import crs as ccrs
 from cartopy.feature import Feature as cFeature
 from cartopy.io.img_tiles import GoogleTiles
@@ -29,14 +30,11 @@ try:
 except ImportError:
     Cube = None
 
-try:
-    from bokeh.models import MercatorTileSource
-except:
-    MercatorTileSource = None
+
 
 try:
     from owslib.wmts import WebMapTileService
-except:
+except ImportError:
     WebMapTileService = None
 
 from ..util import (

--- a/geoviews/element/geo.py
+++ b/geoviews/element/geo.py
@@ -105,14 +105,14 @@ class _Element(Element2D):
             kwargs['crs'] = crs
         elif isinstance(data, _Element):
             kwargs['crs'] = data.crs
-        super(_Element, self).__init__(data, kdims=kdims, vdims=vdims, **kwargs)
+        super().__init__(data, kdims=kdims, vdims=vdims, **kwargs)
 
 
     def clone(self, data=None, shared_data=True, new_type=None,
               *args, **overrides):
         if 'crs' not in overrides and (not new_type or isinstance(new_type, _Element)):
             overrides['crs'] = self.crs
-        return super(_Element, self).clone(data, shared_data, new_type,
+        return super().clone(data, shared_data, new_type,
                                            *args, **overrides)
 
 
@@ -142,7 +142,7 @@ class Feature(_GeoFeature):
         if not isinstance(data, cFeature):
             raise TypeError('%s data has to be an cartopy Feature type'
                             % type(data).__name__)
-        super(Feature, self).__init__(data, kdims=kdims, vdims=vdims, **params)
+        super().__init__(data, kdims=kdims, vdims=vdims, **params)
 
     def __call__(self, *args, **kwargs):
         return self.clone().opts(*args, **kwargs)
@@ -201,7 +201,7 @@ class Feature(_GeoFeature):
                 return util.dimension_range(lower, upper, dim.range, dim.soft_range)
             else:
                 return lower, upper
-        return super(Feature, self).range(dim, data_range, dimension_range)
+        return super().range(dim, data_range, dimension_range)
 
 
 class WMTS(_GeoFeature):
@@ -230,7 +230,7 @@ class WMTS(_GeoFeature):
         elif not isinstance(data, str):
             raise TypeError('%s data should be a tile service URL not a %s type.'
                             % (type(self).__name__, type(data).__name__) )
-        super(WMTS, self).__init__(data, kdims=kdims, vdims=vdims, **params)
+        super().__init__(data, kdims=kdims, vdims=vdims, **params)
 
     def __call__(self, *args, **kwargs):
         return self.opts(*args, **kwargs)
@@ -379,7 +379,7 @@ class QuadMesh(_Element, HvQuadMesh):
         return from_xarray(da, crs, apply_transform, **kwargs)
 
     def trimesh(self):
-        trimesh = super(QuadMesh, self).trimesh()
+        trimesh = super().trimesh()
         node_params = util.get_param_values(trimesh.nodes)
         node_params['crs'] = self.crs
         nodes = TriMesh.node_type(trimesh.nodes.data, **node_params)
@@ -592,7 +592,7 @@ class Graph(_Element, HvGraph):
         else:
             crs = self.crs
 
-        super(Graph, self).__init__(data, kdims, vdims, **params)
+        super().__init__(data, kdims, vdims, **params)
         self.nodes.crs = crs
 
 
@@ -602,7 +602,7 @@ class Graph(_Element, HvGraph):
         Returns the fixed EdgePaths or computes direct connections
         between supplied nodes.
         """
-        edgepaths = super(Graph, self).edgepaths
+        edgepaths = super().edgepaths
         edgepaths.crs = self.crs
         return edgepaths
 
@@ -644,7 +644,7 @@ class TriMesh(HvTriMesh, Graph):
         else:
             crs = self.crs
 
-        super(TriMesh, self).__init__(data, kdims, vdims, **params)
+        super().__init__(data, kdims, vdims, **params)
         self.nodes.crs = crs
 
     @property
@@ -653,7 +653,7 @@ class TriMesh(HvTriMesh, Graph):
         Returns the fixed EdgePaths or computes direct connections
         between supplied nodes.
         """
-        edgepaths = super(TriMesh, self).edgepaths
+        edgepaths = super().edgepaths
         edgepaths.crs = self.crs
         return edgepaths
 
@@ -830,7 +830,7 @@ class Shape(Dataset):
                          'provide the value as part of a dictionary of '
                          'the form {\'geometry\': <shapely.Geometry>, '
                          '\'level\': %s} instead' % params['level'])
-        super(Shape, self).__init__(data, kdims=kdims, vdims=vdims, **params)
+        super().__init__(data, kdims=kdims, vdims=vdims, **params)
 
 
     @classmethod
@@ -938,8 +938,8 @@ class Shape(Dataset):
                 vdims = dataset.vdims
             ddims = dataset.dimensions()
             if None in vdims:
-                raise ValueError('Value dimension %s not found '
-                                 'in dataset dimensions %s' % (value, ddims) )
+                raise ValueError('Value dimension {} not found '
+                                 'in dataset dimensions {}'.format(value, ddims) )
         else:
             vdims = []
 

--- a/geoviews/element/geo.py
+++ b/geoviews/element/geo.py
@@ -228,8 +228,10 @@ class WMTS(_GeoFeature):
         elif WebMapTileService and isinstance(data, WebMapTileService):
             pass
         elif not isinstance(data, str):
-            raise TypeError('%s data should be a tile service URL not a %s type.'
-                            % (type(self).__name__, type(data).__name__) )
+            raise TypeError(
+                f'{type(self).__name__} data should be a tile service '
+                f'URL not a {type(data).__name__} type.'
+            )
         super().__init__(data, kdims=kdims, vdims=vdims, **params)
 
     def __call__(self, *args, **kwargs):
@@ -583,10 +585,11 @@ class Graph(_Element, HvGraph):
             elif edges is not None and type(crs) != type(edges.crs):  # noqa: E721
                 mismatch = 'edges'
             if mismatch:
-                raise ValueError("Coordinate reference system supplied "
-                                 "to %s element must match the crs of "
-                                 "the %s. Expected %s found %s." %
-                                 (mismatch, type(self).__name__, nodes.crs, crs))
+                raise ValueError(
+                    "Coordinate reference system supplied "
+                    f"to {mismatch} element must match the crs of "
+                    f"the {type(self).__name__}. Expected {nodes.crs} found {crs}."
+                )
         elif nodes is not None:
             crs = nodes.crs
             params['crs'] = crs
@@ -635,10 +638,11 @@ class TriMesh(HvTriMesh, Graph):
             elif edges is not None and type(crs) != type(edges.crs):  # noqa: E721
                 mismatch = 'edges'
             if mismatch:
-                raise ValueError("Coordinate reference system supplied "
-                                 "to %s element must match the crs of "
-                                 "the %s. Expected %s found %s." %
-                                 (mismatch, type(self).__name__, nodes.crs, crs))
+                raise ValueError(
+                    "Coordinate reference system supplied "
+                    f"to {mismatch} element must match the crs of "
+                    f"the {type(self).__name__}. Expected {nodes.crs} found {crs}."
+                )
         elif nodes is not None:
             crs = nodes.crs
             params['crs'] = crs

--- a/geoviews/element/geo.py
+++ b/geoviews/element/geo.py
@@ -577,9 +577,9 @@ class Graph(_Element, HvGraph):
         if 'crs' in params:
             crs = params['crs']
             mismatch = None
-            if nodes is not None and type(crs) != type(nodes.crs):
+            if nodes is not None and type(crs) != type(nodes.crs):  # noqa: E721
                 mismatch = 'nodes'
-            elif edges is not None and type(crs) != type(edges.crs):
+            elif edges is not None and type(crs) != type(edges.crs):  # noqa: E721
                 mismatch = 'edges'
             if mismatch:
                 raise ValueError("Coordinate reference system supplied "
@@ -629,9 +629,9 @@ class TriMesh(HvTriMesh, Graph):
         if 'crs' in params:
             crs = params['crs']
             mismatch = None
-            if nodes is not None and type(crs) != type(nodes.crs):
+            if nodes is not None and type(crs) != type(nodes.crs):  # noqa: E721
                 mismatch = 'nodes'
-            elif edges is not None and type(crs) != type(edges.crs):
+            elif edges is not None and type(crs) != type(edges.crs):  # noqa: E721
                 mismatch = 'edges'
             if mismatch:
                 raise ValueError("Coordinate reference system supplied "

--- a/geoviews/links.py
+++ b/geoviews/links.py
@@ -1,13 +1,8 @@
 import param
 
 from holoviews.plotting.links import Link, RectanglesTableLink as HvRectanglesTableLink
-try:
-    from holoviews.plotting.bokeh.links import (
-        LinkCallback, RectanglesTableLinkCallback as HvRectanglesTableLinkCallback
-    )
-except:
-    from holoviews.plotting.bokeh.callbacks import (
-        LinkCallback, RectanglesTableLinkCallback as HvRectanglesTableLinkCallback
+from holoviews.plotting.bokeh.links import (
+    LinkCallback, RectanglesTableLinkCallback as HvRectanglesTableLinkCallback
 )
 from holoviews.core.util import dimension_sanitizer
 

--- a/geoviews/links.py
+++ b/geoviews/links.py
@@ -21,7 +21,7 @@ class PointTableLink(Link):
         if 'point_columns' not in params:
             dimensions = [dimension_sanitizer(d.name) for d in target.dimensions()[:2]]
             params['point_columns'] = dimensions
-        super(PointTableLink, self).__init__(source, target, **params)
+        super().__init__(source, target, **params)
 
 
 class VertexTableLink(Link):
@@ -38,7 +38,7 @@ class VertexTableLink(Link):
         if 'vertex_columns' not in params:
             dimensions = [dimension_sanitizer(d.name) for d in target.dimensions()[:2]]
             params['vertex_columns'] = dimensions
-        super(VertexTableLink, self).__init__(source, target, **params)
+        super().__init__(source, target, **params)
 
 
 class RectanglesTableLink(HvRectanglesTableLink):

--- a/geoviews/operation/__init__.py
+++ b/geoviews/operation/__init__.py
@@ -14,7 +14,7 @@ try:
     from holoviews.operation.datashader import (
         ResamplingOperation, shade, stack, dynspread)
     geo_ops += [ResamplingOperation, shade, stack, dynspread]
-except:
+except ImportError:
     pass
 
 def convert_to_geotype(element, crs=None):

--- a/geoviews/operation/projection.py
+++ b/geoviews/operation/projection.py
@@ -104,13 +104,16 @@ class project_path(_project_operation):
             projected.append(data)
 
         if len(geoms) and len(projected) == 0:
-            self.param.warning('While projecting a %s element from a %s coordinate '
-                         'reference system (crs) to a %s projection none of '
-                         'the projected paths were contained within the bounds '
-                         'specified by the projection. Ensure you have specified '
-                         'the correct coordinate system for your data.' %
-                         (type(element).__name__, type(element.crs).__name__,
-                          type(self.p.projection).__name__))
+            element_name = type(element).__name__
+            crs_name = type(element.crs).__name__
+            proj_name = type(self.p.projection).__name__
+            self.param.warning(
+                f'While projecting a {element_name} element from a {crs_name} coordinate '
+                f'reference system (crs) to a {proj_name} projection none of '
+                'the projected paths were contained within the bounds '
+                'specified by the projection. Ensure you have specified '
+                'the correct coordinate system for your data.'
+            )
 
         # Try casting back to original types
         if element.interface is GeoPandasInterface:
@@ -171,13 +174,16 @@ class project_points(_project_operation):
         new_data[ydim.name] = coordinates[mask, 1]
 
         if len(new_data[xdim.name]) == 0:
-            self.param.warning('While projecting a %s element from a %s coordinate '
-                         'reference system (crs) to a %s projection none of '
-                         'the projected paths were contained within the bounds '
-                         'specified by the projection. Ensure you have specified '
-                         'the correct coordinate system for your data.' %
-                         (type(element).__name__, type(element.crs).__name__,
-                          type(self.p.projection).__name__))
+            element_name = type(element).__name__
+            crs_name = type(element.crs).__name__
+            proj_name = type(self.p.projection).__name__
+            self.param.warning(
+                f'While projecting a {element_name} element from a {crs_name} coordinate '
+                f'reference system (crs) to a {proj_name} projection none of '
+                'the projected paths were contained within the bounds '
+                'specified by the projection. Ensure you have specified '
+                'the correct coordinate system for your data.'
+            )
 
         return element.clone(tuple(new_data[d.name] for d in element.dimensions()),
                              crs=self.p.projection)
@@ -202,13 +208,16 @@ class project_geom(_project_operation):
         new_data[y1d.name] = p2[mask, 1]
 
         if len(new_data[x0d.name]) == 0:
-            self.param.warning('While projecting a %s element from a %s coordinate '
-                         'reference system (crs) to a %s projection none of '
-                         'the projected paths were contained within the bounds '
-                         'specified by the projection. Ensure you have specified '
-                         'the correct coordinate system for your data.' %
-                         (type(element).__name__, type(element.crs).__name__,
-                          type(self.p.projection).__name__))
+            element_name = type(element).__name__
+            crs_name = type(element.crs).__name__
+            proj_name = type(self.p.projection).__name__
+            self.param.warning(
+                f'While projecting a {element_name} element from a {crs_name} coordinate '
+                f'reference system (crs) to a {proj_name} projection none of '
+                'the projected paths were contained within the bounds '
+                'specified by the projection. Ensure you have specified '
+                'the correct coordinate system for your data.'
+            )
 
         return element.clone(tuple(new_data[d.name] for d in element.dimensions()),
                              crs=self.p.projection)

--- a/geoviews/operation/projection.py
+++ b/geoviews/operation/projection.py
@@ -92,7 +92,7 @@ class project_path(_project_operation):
                 logger.setLevel(logging.ERROR)
                 if not proj_geom.is_valid:
                     proj_geom = proj.project_geometry(geom.buffer(0), element.crs)
-            except:
+            except Exception:
                 continue
             finally:
                 logger.setLevel(prev)

--- a/geoviews/operation/projection.py
+++ b/geoviews/operation/projection.py
@@ -238,9 +238,9 @@ class project_quadmesh(_project_operation):
 
         zs = element.dimension_values(2, flat=False)
         if irregular:
-            X, Y = [np.asarray(element.interface.coords(
+            X, Y = (np.asarray(element.interface.coords(
                 element, kd, expanded=True, edges=False))
-                    for kd in element.kdims]
+                    for kd in element.kdims)
         else:
             X = element.interface.coords(element, 0, True, True, False)
             if np.all(X[0, 1:] < X[0, :-1]):

--- a/geoviews/operation/regrid.py
+++ b/geoviews/operation/regrid.py
@@ -1,8 +1,4 @@
 import os
-try:
-    FileNotFoundError
-except NameError:
-    FileNotFoundError = IOError
 
 import param
 import numpy as np
@@ -56,7 +52,7 @@ class weighted_regrid(regrid):
     def _get_regridder(self, element):
         try:
             import xesmf as xe
-        except:
+        except ImportError:
             raise ImportError("xESMF library required for weighted regridding.")
         x, y = element.kdims
         if self.p.target:
@@ -120,11 +116,11 @@ class weighted_regrid(regrid):
         if is_geographic(element):
             try:
                 return Image(ds, crs=element.crs, **params)
-            except:
+            except Exception:
                 return QuadMesh(ds, crs=element.crs, **params)
         try:
             return HvImage(ds, **params)
-        except:
+        except Exception:
             return HvQuadMesh(ds, **params)
 
 

--- a/geoviews/operation/resample.py
+++ b/geoviews/operation/resample.py
@@ -132,7 +132,7 @@ class resample_geometry(Operation):
 
     @param.parameterized.bothmethod
     def instance(self_or_cls,**params):
-        inst = super(resample_geometry, self_or_cls).instance(**params)
+        inst = super().instance(**params)
         inst._cache = {}
         return inst
 

--- a/geoviews/plotting/bokeh/__init__.py
+++ b/geoviews/plotting/bokeh/__init__.py
@@ -36,7 +36,7 @@ class TilePlot(GeoPlot):
     style_opts = ['alpha', 'render_parents', 'level', 'smoothing', 'min_zoom', 'max_zoom']
 
     def get_extents(self, element, ranges, range_type='combined'):
-        extents = super(TilePlot, self).get_extents(element, ranges, range_type)
+        extents = super().get_extents(element, ranges, range_type)
         if (not self.overlaid and all(e is None or not np.isfinite(e) for e in extents)
             and range_type in ('combined', 'data')):
             (x0, x1), (y0, y1) = GOOGLE_MERCATOR.x_limits, GOOGLE_MERCATOR.y_limits
@@ -195,7 +195,7 @@ class GeoShapePlot(GeoPolygonPlot):
         else:
             el_type = Polygons
         polys = el_type([element.data], crs=element.crs, **util.get_param_values(element))
-        return super(GeoShapePlot, self).get_data(polys, ranges, style)
+        return super().get_data(polys, ranges, style)
 
 
 class FeaturePlot(GeoPolygonPlot):
@@ -211,7 +211,7 @@ class FeaturePlot(GeoPolygonPlot):
             return tuple(round(c, 12) for c in (x0, y0, x1, y1))
         elif self.overlaid:
             return (np.NaN,)*4
-        return super(FeaturePlot, self).get_extents(element, ranges, range_type)
+        return super().get_extents(element, ranges, range_type)
 
     def get_data(self, element, ranges, style):
         mapping = dict(self._mapping)
@@ -230,7 +230,7 @@ class FeaturePlot(GeoPolygonPlot):
         else:
             el_type = Polygons
         polys = el_type(geoms, crs=element.crs, **util.get_param_values(element))
-        return super(FeaturePlot, self).get_data(polys, ranges, style)
+        return super().get_data(polys, ranges, style)
 
 
 
@@ -239,7 +239,7 @@ class GeoTextPlot(GeoPlot, TextPlot):
     def get_data(self, element, ranges, style):
         mapping = dict(x='x', y='y', text='text')
         if not self.geographic:
-            return super(GeoTextPlot, self).get_data(element, ranges, style)
+            return super().get_data(element, ranges, style)
         if element.crs:
             x, y = self.projection.transform_point(element.x, element.y,
                                                    element.crs)

--- a/geoviews/plotting/bokeh/callbacks.py
+++ b/geoviews/plotting/bokeh/callbacks.py
@@ -117,27 +117,27 @@ def project_poly(cb, msg):
 class GeoRangeXYCallback(RangeXYCallback):
 
     def _process_msg(self, msg):
-        msg = super(GeoRangeXYCallback, self)._process_msg(msg)
+        msg = super()._process_msg(msg)
         return project_ranges(self, msg, ('x_range', 'y_range'))
 
 class GeoRangeXCallback(RangeXCallback):
 
     def _process_msg(self, msg):
-        msg = super(GeoRangeXCallback, self)._process_msg(msg)
+        msg = super()._process_msg(msg)
         return project_ranges(self, msg, ('x_range',))
 
 
 class GeoRangeYCallback(RangeYCallback):
 
     def _process_msg(self, msg):
-        msg = super(GeoRangeYCallback, self)._process_msg(msg)
+        msg = super()._process_msg(msg)
         return project_ranges(self, msg, ('y_range',))
 
 
 class GeoSelectionXYCallback(SelectionXYCallback):
 
     def _process_msg(self, msg):
-        msg = super(GeoSelectionXYCallback, self)._process_msg(msg)
+        msg = super()._process_msg(msg)
         if (skip(self, msg, ('x_selection', 'y_selection')) or
             not all(isinstance(sel, tuple) for sel in msg.values())):
             return msg
@@ -153,7 +153,7 @@ class GeoSelectionXYCallback(SelectionXYCallback):
 class GeoBoundsXYCallback(BoundsCallback):
 
     def _process_msg(self, msg):
-        msg = super(GeoBoundsXYCallback, self)._process_msg(msg)
+        msg = super()._process_msg(msg)
         if skip(self, msg, ('bounds',)): return msg
         plot = get_cb_plot(self)
         msg['bounds'] = project_extents(msg['bounds'], plot.projection,
@@ -164,7 +164,7 @@ class GeoBoundsXYCallback(BoundsCallback):
 class GeoBoundsXCallback(BoundsXCallback):
 
     def _process_msg(self, msg):
-        msg = super(GeoBoundsXCallback, self)._process_msg(msg)
+        msg = super()._process_msg(msg)
         if skip(self, msg, ('boundsx',)): return msg
         x0, x1 = msg['boundsx']
         plot = get_cb_plot(self)
@@ -176,7 +176,7 @@ class GeoBoundsXCallback(BoundsXCallback):
 class GeoBoundsYCallback(BoundsYCallback):
 
     def _process_msg(self, msg):
-        msg = super(GeoBoundsYCallback, self)._process_msg(msg)
+        msg = super()._process_msg(msg)
         if skip(self, msg, ('boundsy',)): return msg
         y0, y1 = msg['boundsy']
         plot = get_cb_plot(self)
@@ -188,87 +188,87 @@ class GeoBoundsYCallback(BoundsYCallback):
 class GeoPointerXYCallback(PointerXYCallback):
 
     def _process_msg(self, msg):
-        msg = super(GeoPointerXYCallback, self)._process_msg(msg)
+        msg = super()._process_msg(msg)
         return project_point(self, msg)
 
 
 class GeoPointerXCallback(PointerXCallback):
 
     def _process_msg(self, msg):
-        msg = super(GeoPointerXCallback, self)._process_msg(msg)
+        msg = super()._process_msg(msg)
         return project_point(self, msg, ('x',))
 
 
 class GeoPointerYCallback(PointerYCallback):
 
     def _process_msg(self, msg):
-        msg = super(GeoPointerYCallback, self)._process_msg(msg)
+        msg = super()._process_msg(msg)
         return project_point(self, msg, ('y',))
 
 
 class GeoTapCallback(TapCallback):
 
     def _process_msg(self, msg):
-        msg = super(GeoTapCallback, self)._process_msg(msg)
+        msg = super()._process_msg(msg)
         return project_point(self, msg)
 
 
 class GeoSingleTapCallback(SingleTapCallback):
 
     def _process_msg(self, msg):
-        msg = super(GeoSingleTapCallback, self)._process_msg(msg)
+        msg = super()._process_msg(msg)
         return project_point(self, msg)
 
 
 class GeoDoubleTapCallback(DoubleTapCallback):
 
     def _process_msg(self, msg):
-        msg = super(GeoDoubleTapCallback, self)._process_msg(msg)
+        msg = super()._process_msg(msg)
         return project_point(self, msg)
 
 
 class GeoMouseEnterCallback(MouseEnterCallback):
 
     def _process_msg(self, msg):
-        msg = super(GeoMouseEnterCallback, self)._process_msg(msg)
+        msg = super()._process_msg(msg)
         return project_point(self, msg)
 
 
 class GeoMouseLeaveCallback(MouseLeaveCallback):
 
     def _process_msg(self, msg):
-        msg = super(GeoMouseLeaveCallback, self)._process_msg(msg)
+        msg = super()._process_msg(msg)
         return project_point(self, msg)
 
 
 class GeoPolyDrawCallback(PolyDrawCallback):
 
     def _process_msg(self, msg):
-        msg = super(GeoPolyDrawCallback, self)._process_msg(msg)
+        msg = super()._process_msg(msg)
         return project_poly(self, msg)
 
     def _update_cds_vdims(self, data):
         if isinstance(self.source, Shape):
             return
-        super(GeoPolyDrawCallback, self)._update_cds_vdims(data)
+        super()._update_cds_vdims(data)
 
 
 class GeoPolyEditCallback(PolyEditCallback):
 
     def _process_msg(self, msg):
-        msg = super(GeoPolyEditCallback, self)._process_msg(msg)
+        msg = super()._process_msg(msg)
         return project_poly(self, msg)
 
     def _update_cds_vdims(self, data):
         if isinstance(self.source, Shape):
             return
-        super(GeoPolyEditCallback, self)._update_cds_vdims(data)
+        super()._update_cds_vdims(data)
 
 
 class GeoBoxEditCallback(BoxEditCallback):
 
     def _process_msg(self, msg):
-        msg = super(GeoBoxEditCallback, self)._process_msg(msg)
+        msg = super()._process_msg(msg)
         proj = self.plot.projection
         element = self.source
         if isinstance(element, UniformNdMapping):
@@ -291,7 +291,7 @@ class GeoBoxEditCallback(BoxEditCallback):
 class GeoPointDrawCallback(PointDrawCallback):
 
     def _process_msg(self, msg):
-        msg = super(GeoPointDrawCallback, self)._process_msg(msg)
+        msg = super()._process_msg(msg)
         if not msg['data']:
             return msg
 
@@ -402,13 +402,13 @@ class PolyVertexDrawCallback(GeoPolyDrawCallback):
 class GeoFreehandDrawCallback(FreehandDrawCallback):
 
     def _process_msg(self, msg):
-        msg = super(GeoFreehandDrawCallback, self)._process_msg(msg)
+        msg = super()._process_msg(msg)
         return project_poly(self, msg)
 
     def _update_cds_vdims(self, data):
         if isinstance(self.source, Shape):
             return
-        super(GeoFreehandDrawCallback, self)._update_cds_vdims(data)
+        super()._update_cds_vdims(data)
 
 
 callbacks = Stream._callbacks['bokeh']

--- a/geoviews/plotting/bokeh/plot.py
+++ b/geoviews/plotting/bokeh/plot.py
@@ -55,7 +55,7 @@ class GeoPlot(ProjectionPlot, ElementPlot):
     """
 
     def __init__(self, element, **params):
-        super(GeoPlot, self).__init__(element, **params)
+        super().__init__(element, **params)
         self.geographic = is_geographic(self.hmap.last)
         if self.geographic and not isinstance(self.projection, (PlateCarree, Mercator)):
             self.xaxis = None
@@ -66,14 +66,14 @@ class GeoPlot(ProjectionPlot, ElementPlot):
             self.show_bounds = not any(not sb for sb in show_bounds.get('show_bounds', []))
             if self.show_grid:
                 param.main.warning(
-                    'Grid lines do not reflect {0}; to do so '
+                    f'Grid lines do not reflect {self.projection}; to do so '
                     'multiply the current element by gv.feature.grid() '
-                    'and disable the show_grid option.'.format(self.projection)
+                    'and disable the show_grid option.'
                 )
 
     def _axis_properties(self, axis, key, plot, dimension=None,
                          ax_mapping={'x': 0, 'y': 1}):
-        axis_props = super(GeoPlot, self)._axis_properties(axis, key, plot,
+        axis_props = super()._axis_properties(axis, key, plot,
                                                            dimension, ax_mapping)
         proj = self.projection
         if self.geographic and proj is GOOGLE_MERCATOR:
@@ -83,7 +83,7 @@ class GeoPlot(ProjectionPlot, ElementPlot):
         return axis_props
 
     def _update_ranges(self, element, ranges):
-        super(GeoPlot, self)._update_ranges(element, ranges)
+        super()._update_ranges(element, ranges)
         if not self.geographic:
             return
         if self.fixed_bounds:
@@ -104,7 +104,7 @@ class GeoPlot(ProjectionPlot, ElementPlot):
 
     def initialize_plot(self, ranges=None, plot=None, plots=None, source=None):
         opts = {} if isinstance(self, HvOverlayPlot) else {'source': source}
-        fig = super(GeoPlot, self).initialize_plot(ranges, plot, plots, **opts)
+        fig = super().initialize_plot(ranges, plot, plots, **opts)
         if self.geographic and self.show_bounds and not self.overlaid:
             from . import GeoShapePlot
             shape = Shape(self.projection.boundary, crs=self.projection).options(fill_alpha=0)
@@ -115,14 +115,14 @@ class GeoPlot(ProjectionPlot, ElementPlot):
         return fig
 
     def _postprocess_hover(self, renderer, source):
-        super(GeoPlot, self)._postprocess_hover(renderer, source)
+        super()._postprocess_hover(renderer, source)
         hover = self.handles.get('hover')
         if (not self.geographic or hover is None or
             isinstance(hover.tooltips, str) or self.projection is not GOOGLE_MERCATOR
             or hover.tooltips is None or 'hv_created' not in hover.tags):
             return
         element = self.current_frame
-        xdim, ydim = [dimension_sanitizer(kd.name) for kd in element.kdims]
+        xdim, ydim = (dimension_sanitizer(kd.name) for kd in element.kdims)
         formatters, tooltips = dict(hover.formatters), []
         xhover = CustomJSHover(code=self._hover_code % 0)
         yhover = CustomJSHover(code=self._hover_code % 1)
@@ -155,12 +155,12 @@ class GeoPlot(ProjectionPlot, ElementPlot):
             tooltips = [(l, t+'{custom}' if t in hover.formatters else t) for l, t in tooltips]
             hover.tooltips = tooltips
         else:
-            super(GeoPlot, self)._update_hover(element)
+            super()._update_hover(element)
 
     def get_data(self, element, ranges, style):
         if self._project_operation and self.geographic:
             element = self._project_operation(element, projection=self.projection)
-        return super(GeoPlot, self).get_data(element, ranges, style)
+        return super().get_data(element, ranges, style)
 
 
 class GeoOverlayPlot(GeoPlot, HvOverlayPlot):
@@ -176,7 +176,7 @@ class GeoOverlayPlot(GeoPlot, HvOverlayPlot):
                           ['global_extent', 'show_bounds', 'infer_projection'])
 
     def __init__(self, element, **params):
-        super(GeoOverlayPlot, self).__init__(element, **params)
+        super().__init__(element, **params)
         self.geographic = any(element.traverse(is_geographic, [_Element]))
         if self.geographic:
             self.show_grid = False

--- a/geoviews/plotting/bokeh/plot.py
+++ b/geoviews/plotting/bokeh/plot.py
@@ -5,7 +5,7 @@ import param
 
 from cartopy.crs import GOOGLE_MERCATOR, PlateCarree, Mercator
 from bokeh.models.tools import BoxZoomTool, WheelZoomTool
-from bokeh.models import MercatorTickFormatter, MercatorTicker
+from bokeh.models import MercatorTickFormatter, MercatorTicker, CustomJSHover
 from holoviews.core.dimension import Dimension
 from holoviews.core.util import dimension_sanitizer
 from holoviews.plotting.bokeh.element import ElementPlot, OverlayPlot as HvOverlayPlot
@@ -117,11 +117,7 @@ class GeoPlot(ProjectionPlot, ElementPlot):
     def _postprocess_hover(self, renderer, source):
         super(GeoPlot, self)._postprocess_hover(renderer, source)
         hover = self.handles.get('hover')
-        try:
-            from bokeh.models import CustomJSHover
-        except:
-            CustomJSHover = None
-        if (not self.geographic or None in (hover, CustomJSHover) or
+        if (not self.geographic or hover is None or
             isinstance(hover.tooltips, str) or self.projection is not GOOGLE_MERCATOR
             or hover.tooltips is None or 'hv_created' not in hover.tags):
             return

--- a/geoviews/plotting/mpl/__init__.py
+++ b/geoviews/plotting/mpl/__init__.py
@@ -9,7 +9,7 @@ from cartopy.mpl.gridliner import LONGITUDE_FORMATTER, LATITUDE_FORMATTER
 
 try:
     from owslib.wmts import WebMapTileService
-except:
+except ImportError:
     WebMapTileService = None
 
 from holoviews.core import Store, HoloMap, Layout, Overlay, Element, NdLayout

--- a/geoviews/plotting/mpl/__init__.py
+++ b/geoviews/plotting/mpl/__init__.py
@@ -68,7 +68,7 @@ class GeoOverlayPlot(ProjectionPlot, HvOverlayPlot):
     _propagate_options = HvOverlayPlot._propagate_options + ['global_extent']
 
     def __init__(self, element, **params):
-        super(GeoOverlayPlot, self).__init__(element, **params)
+        super().__init__(element, **params)
         plot_opts = self.lookup_options(self.hmap.last, 'plot').options
         self.geographic = any(self.hmap.traverse(is_geographic, [Element]))
         if 'aspect' not in plot_opts and self.geographic:
@@ -80,7 +80,7 @@ class GeoOverlayPlot(ProjectionPlot, HvOverlayPlot):
             xaxis, yaxis = self.xaxis, self.yaxis
             self.xaxis = self.yaxis = None
         try:
-            ret = super(GeoOverlayPlot, self)._finalize_axis(*args, **kwargs)
+            ret = super()._finalize_axis(*args, **kwargs)
         except Exception as e:
             raise e
         finally:
@@ -116,7 +116,7 @@ class GeoPlot(ProjectionPlot, ElementPlot):
         if 'projection' not in params:
             el = element.last if isinstance(element, HoloMap) else element
             params['projection'] = el.crs
-        super(GeoPlot, self).__init__(element, **params)
+        super().__init__(element, **params)
         plot_opts = self.lookup_options(self.hmap.last, 'plot').options
         self.geographic = is_geographic(self.hmap.last)
         if 'aspect' not in plot_opts:
@@ -179,7 +179,7 @@ class GeoPlot(ProjectionPlot, ElementPlot):
             xaxis, yaxis = self.xaxis, self.yaxis
             self.xaxis = self.yaxis = None
         try:
-            ret = super(GeoPlot, self)._finalize_axis(*args, **kwargs)
+            ret = super()._finalize_axis(*args, **kwargs)
         except Exception as e:
             raise e
         finally:
@@ -202,7 +202,7 @@ class GeoPlot(ProjectionPlot, ElementPlot):
     def get_data(self, element, ranges, style):
         if self._project_operation and self.geographic:
             element = self._project_operation(element, projection=self.projection)
-        return super(GeoPlot, self).get_data(element, ranges, style)
+        return super().get_data(element, ranges, style)
 
     def teardown_handles(self):
         """
@@ -334,7 +334,7 @@ class GeometryPlot(GeoPlot):
             artist = ax.add_geometries(*plot_args, **plot_kwargs)
             return {'artist': artist}
         else:
-            return super(GeometryPlot, self).init_artist(ax, plot_args, plot_kwargs)
+            return super().init_artist(ax, plot_args, plot_kwargs)
 
 
 class GeoPathPlot(GeoPlot, PathPlot):

--- a/geoviews/plotting/plot.py
+++ b/geoviews/plotting/plot.py
@@ -64,7 +64,7 @@ class ProjectionPlot(param.Parameterized):
         if self.global_extent and range_type in ('combined', 'data'):
             (x0, x1), (y0, y1) = proj.x_limits, proj.y_limits
             return (x0, y0, x1, y1)
-        extents = super(ProjectionPlot, self).get_extents(element, ranges, range_type)
+        extents = super().get_extents(element, ranges, range_type)
         if not getattr(element, 'crs', None) or not self.geographic:
             return extents
         elif any(e is None or not np.isfinite(e) for e in extents):

--- a/geoviews/streams.py
+++ b/geoviews/streams.py
@@ -18,7 +18,7 @@ class PolyVertexEdit(PolyEdit):
     def __init__(self, node_style={}, feature_style={}, **params):
         self.node_style = node_style
         self.feature_style = feature_style
-        super(PolyVertexEdit, self).__init__(**params)
+        super().__init__(**params)
 
 
 class PolyVertexDraw(PolyDraw):
@@ -38,4 +38,4 @@ class PolyVertexDraw(PolyDraw):
     def __init__(self, node_style={}, feature_style={}, **params):
         self.node_style = node_style
         self.feature_style = feature_style
-        super(PolyVertexDraw, self).__init__(**params)
+        super().__init__(**params)

--- a/geoviews/tests/__init__.py
+++ b/geoviews/tests/__init__.py
@@ -2,5 +2,5 @@ try:
     # Standardize backend due to random inconsistencies
     from matplotlib import pyplot
     pyplot.switch_backend('agg')
-except:
+except ImportError:
     pass

--- a/geoviews/tests/__init__.py
+++ b/geoviews/tests/__init__.py
@@ -1,6 +1,6 @@
 try:
     # Standardize backend due to random inconsistencies
-    from matplotlib import pyplot
-    pyplot.switch_backend('agg')
+    import matplotlib.pyplot as plt
+    plt.switch_backend('agg')
 except ImportError:
     pass

--- a/geoviews/tests/data/test_geopandas.py
+++ b/geoviews/tests/data/test_geopandas.py
@@ -136,7 +136,7 @@ class GeoPandasInterfaceTest(GeomInterfaceTest, GeomTests, RoundTripTests):
     def setUp(self):
         if geopandas is None:
             raise SkipTest('GeoPandasInterface requires geopandas, skipping tests')
-        super(GeoPandasInterfaceTest, self).setUp()
+        super().setUp()
 
     def test_df_dataset(self):
         if not pd:

--- a/geoviews/tests/data/test_geopandas.py
+++ b/geoviews/tests/data/test_geopandas.py
@@ -10,7 +10,7 @@ from shapely import geometry as sgeom
 try:
     import geopandas
     from geopandas.array import GeometryDtype
-except:
+except ImportError:
     geopandas = None
 
 from holoviews.core.util import pd

--- a/geoviews/tests/data/test_multigeometry.py
+++ b/geoviews/tests/data/test_multigeometry.py
@@ -14,12 +14,12 @@ from holoviews.tests.core.data.test_multiinterface import MultiBaseInterfaceTest
 
 try:
     from shapely import geometry as sgeom
-except:
+except ImportError:
     sgeom = None
 
 try:
     import spatialpandas
-except:
+except ImportError:
     spatialpandas = None
 
 from geoviews.data.geom_dict import GeomDictInterface

--- a/geoviews/tests/data/test_multigeometry.py
+++ b/geoviews/tests/data/test_multigeometry.py
@@ -35,7 +35,7 @@ class GeomInterfaceTest(ComparisonTestCase):
     def setUp(self):
         if sgeom is None:
             raise SkipTest('GeomInterfaceTest requires shapely, skipping tests')
-        super(GeomInterfaceTest, self).setUp()
+        super().setUp()
 
     def test_multi_geom_dataset_geom_list_constructor(self):
         geoms = [sgeom.Polygon([(0, 0), (3, 3), (6, 0)])]
@@ -138,7 +138,7 @@ class SpatialPandasGeomInterfaceTest(GeomInterfaceTest):
     def setUp(self):
         if spatialpandas is None:
             raise SkipTest('SpatialPandasInterface requires spatialpandas, skipping tests')
-        super(SpatialPandasGeomInterfaceTest, self).setUp()
+        super().setUp()
 
 
 class MultiGeomDictInterfaceTest(MultiBaseInterfaceTest):

--- a/geoviews/util.py
+++ b/geoviews/util.py
@@ -100,11 +100,11 @@ def project_extents(extents, src_proj, dest_proj, tol=1e-6):
         except ValueError:
             src_name =type(src_proj).__name__
             dest_name =type(dest_proj).__name__
-            raise ValueError('Could not project data from %s projection '
-                             'to %s projection. Ensure the coordinate '
-                             'reference system (crs) matches your data '
-                             'and the kdims.' %
-                             (src_name, dest_name))
+            raise ValueError(
+                f'Could not project data from {src_name} projection '
+                f'to {dest_name} projection. Ensure the coordinate '
+                'reference system (crs) matches your data and the kdims.'
+            )
     else:
         geom_in_crs = boundary_poly.intersection(domain_in_src_proj)
     return geom_in_crs.bounds

--- a/geoviews/util.py
+++ b/geoviews/util.py
@@ -366,9 +366,8 @@ def geom_length(geom):
     if shapely_version < Version('1.8.0'):
         if not geom.geom_type.startswith('Multi') and hasattr(geom, 'array_interface_base'):
             return len(geom.array_interface_base['data'])//2
-    else:
-        if not geom.geom_type.startswith('Multi'):
-            return len(geom.coords)
+    elif not geom.geom_type.startswith('Multi'):
+        return len(geom.coords)
     # MultiPolygon, MultiPoint, MultiLineString (recursively)
     glength = len(geom.geoms)
     length = 0
@@ -462,7 +461,7 @@ def check_crs(crs):
     import pyproj
     if isinstance(crs, pyproj.Proj):
         out = crs
-    elif isinstance(crs, dict) or isinstance(crs, str):
+    elif isinstance(crs, (str, dict)):
         try:
             out = pyproj.Proj(crs)
         except RuntimeError:

--- a/geoviews/util.py
+++ b/geoviews/util.py
@@ -95,7 +95,7 @@ def project_extents(extents, src_proj, dest_proj, tol=1e-6):
         try:
             geom_clipped_to_dest_proj = dest_poly.intersection(
                 geom_in_src_proj)
-        except:
+        except Exception:
             geom_clipped_to_dest_proj = None
         if geom_clipped_to_dest_proj:
             geom_in_src_proj = geom_clipped_to_dest_proj
@@ -535,7 +535,7 @@ def proj_to_cartopy(proj):
         v = s[1].strip()
         try:
             v = float(v)
-        except:
+        except Exception:
             pass
         if k == 'proj':
             if v == 'tmerc':
@@ -586,7 +586,7 @@ def process_crs(crs):
     try:
         import cartopy.crs as ccrs
         import geoviews as gv # noqa
-    except:
+    except ImportError:
         raise ImportError('Geographic projection support requires GeoViews and cartopy.')
 
     if crs is None:
@@ -595,14 +595,14 @@ def process_crs(crs):
     if isinstance(crs, str) and crs.lower().startswith('epsg'):
         try:
             crs = ccrs.epsg(crs[5:].lstrip().rstrip())
-        except:
+        except Exception:
             raise ValueError("Could not parse EPSG code as CRS, must be of the format 'EPSG: {code}.'")
     elif isinstance(crs, int):
         crs = ccrs.epsg(crs)
     elif isinstance(crs, str) or is_pyproj(crs):
         try:
             crs = proj_to_cartopy(crs)
-        except:
+        except Exception:
             raise ValueError("Could not parse EPSG code as CRS, must be of the format 'proj4: {proj4 string}.'")
     elif not isinstance(crs, ccrs.CRS):
         raise ValueError("Projection must be defined as a EPSG code, proj4 string, cartopy CRS or pyproj.Proj.")
@@ -637,7 +637,7 @@ def load_tiff(filename, crs=None, apply_transform=False, nan_nodata=False, **kwa
     """
     try:
         import xarray as xr
-    except:
+    except ImportError:
         raise ImportError('Loading tiffs requires xarray to be installed')
 
     with warnings.catch_warnings():
@@ -677,7 +677,7 @@ def from_xarray(da, crs=None, apply_transform=False, nan_nodata=False, **kwargs)
     elif hasattr(da, 'crs'):
         try:
             kwargs['crs'] = process_crs(da.crs)
-        except:
+        except Exception:
             param.main.warning('Could not decode projection from crs string %r, '
                                'defaulting to non-geographic element.' % da.crs)
 

--- a/geoviews/util.py
+++ b/geoviews/util.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import sys
 import warnings
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,43 @@ requires = [
     "setuptools",
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.ruff]
+target-version = "py38"
+
+select = [
+    "E",
+    "F",
+    # "ICN",
+    # "PLC",
+    # "PLE",
+    # "PLR",
+    # "PLW",
+    # "RUF",
+    # "UP",
+    # "W",
+]
+
+ignore = [
+    "E402",     # Module level import not at top of file
+    "E501",     # Line too long
+    "E712",     # Comparison to true should be is
+    "E731",     # Do not assign a lambda expression, use a def
+    "E741",     # Ambiguous variable name
+    "F405",     # From star imports
+    "PLR2004",  # Magic value used in comparison
+    "RUF005",   # Consider {expr} instead of concatenation
+    "PLR091",   # Too many arguments/branches/statements
+    "PLE0604",  # Invalid object in `__all__`, must contain only strings
+    "PLE0605",  # Invalid format for __all__
+    "E701",     # Multiple statements on one line
+]
+
+fix = true
+unfixable = [
+    "F401",     # Unused imports
+]
+
+[tool.ruff.per-file-ignores]
+"__init__.py" = ["F403"]
+"geoviews/tests/*" = ["RUF001", "RUF002", "RUF003"]  # Ambiguous unicode character

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,14 +14,14 @@ target-version = "py38"
 select = [
     "E",
     "F",
-    # "ICN",
+    "ICN",
     # "PLC",
     # "PLE",
     # "PLR",
     # "PLW",
-    # "RUF",
+    "RUF",
     # "UP",
-    # "W",
+    "W",
 ]
 
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ select = [
     "PLR",
     "PLW",
     "RUF",
-    # "UP",
+    "UP",
     "W",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,10 @@ select = [
     "E",
     "F",
     "ICN",
-    # "PLC",
-    # "PLE",
-    # "PLR",
-    # "PLW",
+    "PLC",
+    "PLE",
+    "PLR",
+    "PLW",
     "RUF",
     # "UP",
     "W",
@@ -36,6 +36,7 @@ ignore = [
     "PLR091",   # Too many arguments/branches/statements
     "PLE0604",  # Invalid object in `__all__`, must contain only strings
     "PLE0605",  # Invalid format for __all__
+    "PLW2901",  # For loop variable overwritten
     "E701",     # Multiple statements on one line
 ]
 


### PR DESCRIPTION
This PR updates Geoviews to use Ruff instead of Flake8. Most of the code changes are related to following the rules. 

I have removed the safeguard for Holoviews and Bokeh versions as I expect this to be released in 1.10 which supports Bokeh 3 and up with #625. 

I have also removed `cyODict` as it is an `OrderedDict`. 