### PR TITLE
Fix build

### DIFF
--- a/geoviews/operation/projection.py
+++ b/geoviews/operation/projection.py
@@ -5,7 +5,6 @@ import param
 import numpy as np
 
 from cartopy import crs as ccrs
-from cartopy.img_transform import warp_array, _determine_bounds
 from holoviews.core.data import MultiInterface
 from holoviews.core.util import cartesian_product, get_param_values, pd
 from holoviews.operation import Operation
@@ -327,6 +326,8 @@ class project_image(_project_operation):
     supported_types = [Image, RGB]
 
     def _process(self, img, key=None):
+        from cartopy.img_transform import warp_array
+
         if self.p.fast:
             return self._fast_process(img, key)
 
@@ -367,6 +368,8 @@ class project_image(_project_operation):
                          ydensity=None)
 
     def _fast_process(self, element, key=None):
+        from cartopy.img_transform import _determine_bounds
+
         # Project coordinates
         proj = self.p.projection
         if proj == element.crs:

--- a/geoviews/operation/projection.py
+++ b/geoviews/operation/projection.py
@@ -3,10 +3,11 @@ import sys
 
 import param
 import numpy as np
+import pandas as pd
 
 from cartopy import crs as ccrs
 from holoviews.core.data import MultiInterface
-from holoviews.core.util import cartesian_product, get_param_values, pd
+from holoviews.core.util import cartesian_product, get_param_values
 from holoviews.operation import Operation
 from shapely.geometry import Polygon, MultiPolygon
 from shapely.geometry.collection import GeometryCollection

--- a/geoviews/tests/data/test_geopandas.py
+++ b/geoviews/tests/data/test_geopandas.py
@@ -4,6 +4,7 @@ Test for the GeoPandasInterface
 from unittest import SkipTest
 
 import numpy as np
+import pandas as pd
 
 from shapely import geometry as sgeom
 
@@ -13,7 +14,6 @@ try:
 except ImportError:
     geopandas = None
 
-from holoviews.core.util import pd
 from holoviews.core.data import Dataset
 from holoviews.core.data.interface import DataError
 from holoviews.element import Polygons, Path, Points

--- a/geoviews/tests/data/test_multigeometry.py
+++ b/geoviews/tests/data/test_multigeometry.py
@@ -4,10 +4,10 @@ Test for the MultiInterface and GeomDictInterface
 from unittest import SkipTest
 
 import numpy as np
+import pandas as pd
 
 from holoviews.core.data import Dataset, MultiInterface
 from holoviews.core.data.interface import DataError
-from holoviews.core.util import pd
 from holoviews.element import Polygons, Path
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews.tests.core.data.test_multiinterface import MultiBaseInterfaceTest

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ _required = [
     'numpy',
     'shapely',
     'param',
-    'panel',
+    'panel >=1.0.0rc1',
     'pyproj',
 ]
 


### PR DESCRIPTION
`cartopy.img_transform` try to import `pykdtree.kdtree` or `scipy.spatial`, which are not required dependencies.  

First observed here: https://github.com/holoviz/geoviews/actions/runs/4838011712/jobs/8622224254