### PR TITLE
Use geodatasets for geodatasources

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: doit develop_install
         run: |
           conda activate test-environment
-          doit develop_install -o doc -o examples
+          doit develop_install -o doc -o examples_extra
       - name: doit env_capture
         run: |
           conda activate test-environment

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,7 +56,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           channel-priority: strict
           channels: pyviz/label/dev,bokeh,conda-forge,nodefaults
-          envs: "-o tests -o examples -o recommended"
+          envs: "-o tests -o examples_extra -o recommended"
           cache: true
           conda-update: true
           conda-mamba: mamba

--- a/examples/Homepage.ipynb
+++ b/examples/Homepage.ipynb
@@ -70,8 +70,10 @@
    "outputs": [],
    "source": [
     "import geopandas as gpd\n",
-    "gv.Polygons(gpd.read_file(gpd.datasets.get_path('naturalearth_lowres')), vdims=['pop_est', ('name', 'Country')]).opts(\n",
-    "    tools=['hover'], width=600, projection=crs.Robinson()\n",
+    "\n",
+    "data_url = \"https://www.naturalearthdata.com/http//www.naturalearthdata.com/download/110m/cultural/ne_110m_admin_0_countries.zip\"\n",
+    "gv.Polygons(gpd.read_file(data_url), vdims=[(\"POP_EST\", \"Population estimate\"), (\"NAME\", \"Country\")]).opts(\n",
+    "    tools=[\"hover\"], width=600, projection=crs.Robinson()\n",
     ")"
    ]
   }

--- a/examples/Homepage.ipynb
+++ b/examples/Homepage.ipynb
@@ -70,11 +70,11 @@
    "outputs": [],
    "source": [
     "import geopandas as gpd\n",
+    "import geodatasets as gds\n",
     "\n",
-    "data_url = \"https://www.naturalearthdata.com/http//www.naturalearthdata.com/download/110m/cultural/ne_110m_admin_0_countries.zip\"\n",
-    "gv.Polygons(gpd.read_file(data_url), vdims=[(\"POP_EST\", \"Population estimate\"), (\"NAME\", \"Country\")]).opts(\n",
-    "    tools=[\"hover\"], width=600, projection=crs.Robinson()\n",
-    ")"
+    "nybb = gpd.read_file(gds.get_path('nybb'))\n",
+    "poly_data = nybb.to_crs(crs.GOOGLE_MERCATOR.proj4_init)\n",
+    "gv.tile_sources.OSM * gv.Polygons(poly_data, vdims='BoroName', crs=crs.GOOGLE_MERCATOR).opts(height=500, width=500, tools=[\"hover\"])"
    ]
   }
  ],
@@ -85,5 +85,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/examples/gallery/bokeh/new_york_boroughs.ipynb
+++ b/examples/gallery/bokeh/new_york_boroughs.ipynb
@@ -30,7 +30,7 @@
     "tiles = gv.tile_sources.Wikipedia\n",
     "\n",
     "# Project data to Web Mercator\n",
-    "nybb = gpd.read_file(gpd.datasets.get_path('nybb'))\n",
+    "nybb = gpd.read_file(gds.get_path('nybb'))\n",
     "poly_data = nybb.to_crs(ccrs.GOOGLE_MERCATOR.proj4_init)\n",
     "polys = gv.Polygons(poly_data, vdims=['BoroName'], crs=ccrs.GOOGLE_MERCATOR)"
    ]

--- a/examples/gallery/bokeh/new_york_boroughs.ipynb
+++ b/examples/gallery/bokeh/new_york_boroughs.ipynb
@@ -6,6 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import geodatasets as gds\n",
     "import geopandas as gpd\n",
     "import geoviews as gv\n",
     "import cartopy.crs as ccrs\n",

--- a/examples/gallery/matplotlib/new_york_boroughs.ipynb
+++ b/examples/gallery/matplotlib/new_york_boroughs.ipynb
@@ -6,6 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import geodatasets as gds\n",
     "import geopandas as gpd\n",
     "import geoviews as gv\n",
     "import cartopy.crs as ccrs\n",
@@ -30,7 +31,7 @@
     "tiles = gv.tile_sources.Wikipedia \n",
     "\n",
     "# Project data to Web Mercator\n",
-    "nybb = gpd.read_file(gpd.datasets.get_path('nybb'))\n",
+    "nybb = gpd.read_file(gds.get_path('nybb'))\n",
     "poly_data = nybb.to_crs(ccrs.GOOGLE_MERCATOR.proj4_init)\n",
     "polys = gv.Polygons(poly_data, vdims='BoroName', crs=ccrs.GOOGLE_MERCATOR)"
    ]

--- a/examples/user_guide/Geometries.ipynb
+++ b/examples/user_guide/Geometries.ipynb
@@ -264,7 +264,7 @@
    "metadata": {},
    "source": [
     "GeoPandas extends the datatypes used by pandas to allow spatial operations on geometric types, which makes it a very convenient way of working with geometries with associated variables. GeoViews ``Path``, ``Contours`` and ``Polygons`` Elements natively support projecting and plotting of\n",
-    "geopandas DataFrames using both ``matplotlib`` and ``bokeh`` plotting extensions. We will load the example dataset of the world which also includes some additional data about each country:"
+    "geopandas DataFrames using both ``matplotlib`` and ``bokeh`` plotting extensions. We will load an example dataset of Airbnb rentals in Chicago, which also includes some additional data about the city's communities:"
    ]
   },
   {
@@ -273,17 +273,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import geodatasets as gds\n",
     "import geopandas as gpd\n",
-    "data_url = \"https://www.naturalearthdata.com/http//www.naturalearthdata.com/download/110m/cultural/ne_110m_admin_0_countries.zip\"\n",
-    "world = gpd.read_file(data_url)\n",
-    "world[[\"NAME\", \"CONTINENT\", \"POP_EST\", \"geometry\"]].head()"
+    "\n",
+    "data = gpd.read_file(gds.get_path('geoda airbnb'))\n",
+    "data[[\"community\", \"population\", \"num_spots\", \"geometry\"]].head()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can simply pass the GeoPandas DataFrame to a Polygons, Path or Contours element and it will plot the data for us. The ``Contours`` and ``Polygons`` will automatically color the data by the first specified value dimension defined by the ``vdims`` keyword (the geometries may be colored by any dimension using the ``color_index`` plot option):"
+    "We can simply pass the GeoPandas DataFrame to a Polygons, Path or Contours element and it will plot the data for us. The ``Contours`` and ``Polygons`` will automatically color the data by the first specified value dimension defined by the ``vdims`` keyword (the geometries may be colored by any dimension using the ``color`` plot option):"
    ]
   },
   {
@@ -292,14 +293,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gv.Polygons(world, vdims='POP_EST').opts(projection=ccrs.Robinson(), width=600, tools=['hover'])"
+    "poly_plot = gv.Polygons(data, vdims=[\"population\", \"community\", \"num_spots\"]).opts(width=600, height=600)\n",
+    "gv.tile_sources.OSM * poly_plot"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Geometries can be displayed using both matplotlib and bokeh, here we will switch to bokeh allowing us to color by a categorical variable (``continent``) and activating the hover tool to reveal information about the plot."
+    "Here we will switch the color by number of spots (``num_spots``) and activating the hover tool to reveal information about the plot. The switch will work in both Matplotlib and Nokeh, but the bokeh version will be more interactive:"
    ]
   },
   {
@@ -308,8 +310,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gv.Polygons(world, vdims=['CONTINENT', 'NAME', 'POP_EST']).opts(\n",
-    "    cmap='tab20', width=600, height=400, tools=['hover'], infer_projection=True)"
+    "gv.tile_sources.OSM * poly_plot.opts(color=\"num_spots\", cmap='tab20', tools=['hover'])"
    ]
   },
   {
@@ -327,5 +328,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/examples/user_guide/Geometries.ipynb
+++ b/examples/user_guide/Geometries.ipynb
@@ -274,8 +274,9 @@
    "outputs": [],
    "source": [
     "import geopandas as gpd\n",
-    "world = gpd.read_file(gpd.datasets.get_path('naturalearth_lowres'))\n",
-    "world.head()"
+    "data_url = \"https://www.naturalearthdata.com/http//www.naturalearthdata.com/download/110m/cultural/ne_110m_admin_0_countries.zip\"\n",
+    "world = gpd.read_file(data_url)\n",
+    "world[[\"NAME\", \"CONTINENT\", \"POP_EST\", \"geometry\"]].head()"
    ]
   },
   {
@@ -291,7 +292,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gv.Polygons(world, vdims='pop_est').opts(projection=ccrs.Robinson(), width=600, tools=['hover'])"
+    "gv.Polygons(world, vdims='POP_EST').opts(projection=ccrs.Robinson(), width=600, tools=['hover'])"
    ]
   },
   {
@@ -307,7 +308,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gv.Polygons(world, vdims=['continent',  'name', 'pop_est']).opts(\n",
+    "gv.Polygons(world, vdims=['CONTINENT', 'NAME', 'POP_EST']).opts(\n",
     "    cmap='tab20', width=600, height=400, tools=['hover'], infer_projection=True)"
    ]
   },

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,8 @@ _examples_extra = _recommended + [
     'iris',
     'xesmf',
     'mock',
-    'fiona'
+    'fiona',
+    'geodatasets',
 ]
 
 extras_require={


### PR DESCRIPTION
We are starting to get warnings that `geopandas.datasets` is deprecated for `geodatasets`. 
![image](https://github.com/holoviz/geoviews/assets/19758978/85f9bae9-6d14-454a-b104-c9f5e3cac063)

The changes in this PR update the `nybb` to use geodatasets. 

Changed `naturalearth_lowres` to use geodatasets airbnb.
