### PR TITLE
Make states fill_color="none" (transparent)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,13 @@ This release adds Bokeh 3 support to Geoviews, along with bug fixes and enhancem
 
 This release also deprecates the `Wikipedia` tile source. If you are using this tile source, please switch to the `OSM` tile source instead. The `Wikipedia` tile source will be removed in version 1.11.0. `geoviews.util.load_tiff` has also been deprecated `rioxarray.open_rasterio` to load GeoTIFFs into a `xarray.DataArray`.
 
+Note, this release has a minor breaking change where `gv.feature.states` defaults to `fill_color=None` so the fill color is transparent.
+
 Enhancements:
 
 - Add Bokeh 3 support to GeoViews ([#625](https://github.com/holoviz/geoviews/pull/625))
 - Add `PandasAPI` to `GeoPandasInterface` ([#620](https://github.com/holoviz/geoviews/pull/620))
+- Updated the default for `gv.feature.states` to `fill_color=None` ([#643](https://github.com/holoviz/geoviews/pull/643))
 
 Bug fixes:
 

--- a/doc/releases.rst
+++ b/doc/releases.rst
@@ -26,7 +26,7 @@ Enhancements:
 -  Add ``PandasAPI`` to ``GeoPandasInterface``
    (`#620 <https://github.com/holoviz/geoviews/pull/620>`__)
 -  Updated the default for ``gv.feature.states`` to ``fill_color=None``
-   (`#620 <https://github.com/holoviz/geoviews/pull/643>`__)
+   (`#643 <https://github.com/holoviz/geoviews/pull/643>`__)
 
 Bug fixes:
 

--- a/doc/releases.rst
+++ b/doc/releases.rst
@@ -25,7 +25,7 @@ Enhancements:
    (`#625 <https://github.com/holoviz/geoviews/pull/625>`__)
 -  Add ``PandasAPI`` to ``GeoPandasInterface``
    (`#620 <https://github.com/holoviz/geoviews/pull/620>`__)
-- Updated the default for ``gv.feature.states`` to ``fill_color=None``
+-  Updated the default for ``gv.feature.states`` to ``fill_color=None``
    (`#620 <https://github.com/holoviz/geoviews/pull/643>`__)
 
 Bug fixes:

--- a/doc/releases.rst
+++ b/doc/releases.rst
@@ -7,7 +7,7 @@ Version 1.10.0
 Date: May 24, 2023
 
 This release adds Bokeh 3 support to Geoviews, along with bug fixes and
-enhancements. Many thanks to @maximlt, @philippjfr, and @Hoxbro.
+enhancements. Many thanks to @maximlt, @philippjfr, @Hoxbro, and @ahuang11.
 
 This release also deprecates the ``Wikipedia`` tile source. If you are
 using this tile source, please switch to the ``OSM`` tile source
@@ -16,12 +16,17 @@ instead. The ``Wikipedia`` tile source will be removed in version
 ``rioxarray.open_rasterio`` to load GeoTIFFs into a
 ``xarray.DataArray``.
 
+Note, this release has a minor breaking change where `gv.feature.states`
+defaults to `fill_color=None` so the fill color is transparent.
+
 Enhancements:
 
 -  Add Bokeh 3 support to GeoViews
    (`#625 <https://github.com/holoviz/geoviews/pull/625>`__)
 -  Add ``PandasAPI`` to ``GeoPandasInterface``
    (`#620 <https://github.com/holoviz/geoviews/pull/620>`__)
+- Updated the default for ``gv.feature.states`` to ``fill_color=None``
+   (`#620 <https://github.com/holoviz/geoviews/pull/643>`__)
 
 Bug fixes:
 

--- a/geoviews/plotting/bokeh/__init__.py
+++ b/geoviews/plotting/bokeh/__init__.py
@@ -307,4 +307,5 @@ options.Feature.Ocean  = Options('style', fill_color='#97b6e1', line_color='#97b
 options.Feature.Lakes  = Options('style', fill_color='#97b6e1', line_color='#97b6e1')
 options.Feature.Rivers = Options('style', line_color='#97b6e1')
 options.Feature.Grid = Options('style', line_width=0.5, alpha=0.5, line_color='gray')
+options.Feature.States = Options('style', fill_color="none")
 options.Shape = Options('style', line_color='black', fill_color='#30A2DA')

--- a/geoviews/plotting/bokeh/__init__.py
+++ b/geoviews/plotting/bokeh/__init__.py
@@ -307,5 +307,5 @@ options.Feature.Ocean  = Options('style', fill_color='#97b6e1', line_color='#97b
 options.Feature.Lakes  = Options('style', fill_color='#97b6e1', line_color='#97b6e1')
 options.Feature.Rivers = Options('style', line_color='#97b6e1')
 options.Feature.Grid = Options('style', line_width=0.5, alpha=0.5, line_color='gray')
-options.Feature.States = Options('style', fill_color="none")
+options.Feature.States = Options('style', fill_color=None)
 options.Shape = Options('style', line_color='black', fill_color='#30A2DA')


### PR DESCRIPTION
Closes https://github.com/holoviz/geoviews/issues/512 (not sure why I closed the previous PR; perhaps because it was stale).

Also not sure if it's a better choice to set fill_alpha vs fill_color. I leaned towards fill_color rather than fill_alpha because I worry users might be confused if they change fill_color and it doesn't show anything.

I would like to skip importing and calling geoviews:
```python
import pandas as pd
import hvplot.pandas
import geoviews as gv

df = pd.read_html(
    "https://mesonet.agron.iastate.edu/sites/networks.php?station=ORD&network=IL_ASOS"
)[1]
# make snake case
df.columns = df.columns.str.lower().str.replace(" ", "_")

map = df.hvplot.points(
    "longitude1",
    "latitude1",
    geo=True,
)

# overlay the map
states = gv.feature.states(fill_color="none")
map * states
```
<img width="223" alt="image" src="https://github.com/holoviz/geoviews/assets/15331990/f73b2076-bc9f-4076-a1e5-eb96d0039ed4">


And instead, do this:
```python
import pandas as pd
import hvplot.pandas

df = pd.read_html(
    "https://mesonet.agron.iastate.edu/sites/networks.php?station=ORD&network=IL_ASOS"
)[1]
# make snake case
df.columns = df.columns.str.lower().str.replace(" ", "_")

map = df.hvplot.points(
    "longitude1",
    "latitude1",
    geo=True,
    features=["states"]
)

# overlay the map
map
```

At the moment, it shows this:
<img width="216" alt="image" src="https://github.com/holoviz/geoviews/assets/15331990/7be06a92-09c2-4a3b-b0e5-ba2243ef157e">
