### PR TITLE
Update to Google Analytics 4

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -39,7 +39,7 @@ html_theme_options = {
             "icon": "fa-brands fa-discord",
         },
     ],
-    "analytics": {"google_analytics_id": "UA-154795830-3"},
+    "analytics": {"google_analytics_id": "G-XTWHHEZL7Q"},
     "pygment_dark_style": "material"
 }
 


### PR DESCRIPTION
Updates tracking ID to the new GA4 since the old Universal Tracking is shutting down and we haven't yet decided to move away from GA.