### PR TITLE
Add WindBarbs to Matplotlib Backend

### DIFF
--- a/examples/gallery/bokeh/orthographic_vectorfield.ipynb
+++ b/examples/gallery/bokeh/orthographic_vectorfield.ipynb
@@ -48,7 +48,7 @@
     "\n",
     "xs, ys, U, V, crs = sample_data()\n",
     "mag = np.sqrt(U**2 + V**2)\n",
-    "angle = (np.pi/2.) - np.arctan2(U/mag, V/mag)\n",
+    "angle = np.pi / 2 - np.arctan2(-V, -U)\n",
     "vectorfield = gv.VectorField((xs, ys, angle, mag), crs=crs)"
    ]
   },

--- a/examples/gallery/bokeh/vectorfield_example.ipynb
+++ b/examples/gallery/bokeh/vectorfield_example.ipynb
@@ -47,7 +47,7 @@
     "\n",
     "xs, ys, U, V, crs = sample_data()\n",
     "mag = np.sqrt(U**2 + V**2)\n",
-    "angle = (np.pi/2.) - np.arctan2(U/mag, V/mag)\n",
+    "angle = np.pi / 2 - np.arctan2(-V, -U)\n",
     "tiles = gv.tile_sources.OSM\n",
     "vectorfield = gv.VectorField((xs, ys, angle, mag), crs=crs)"
    ]

--- a/examples/gallery/matplotlib/orthographic_vectorfield.ipynb
+++ b/examples/gallery/matplotlib/orthographic_vectorfield.ipynb
@@ -50,7 +50,7 @@
     "\n",
     "xs, ys, U, V, crs = sample_data()\n",
     "mag = np.sqrt(U**2 + V**2)\n",
-    "angle = (np.pi/2.) - np.arctan2(U/mag, V/mag)\n",
+    "angle = np.pi / 2 - np.arctan2(-V, -U)\n",
     "vectorfield = gv.VectorField((xs, ys, angle, mag), crs=crs)"
    ]
   },

--- a/examples/gallery/matplotlib/vectorfield_example.ipynb
+++ b/examples/gallery/matplotlib/vectorfield_example.ipynb
@@ -49,7 +49,7 @@
     "\n",
     "xs, ys, U, V, crs = sample_data()\n",
     "mag = np.sqrt(U**2 + V**2)\n",
-    "angle = (np.pi/2.) - np.arctan2(U/mag, V/mag)\n",
+    "angle = np.pi / 2 - np.arctan2(-V, -U)\n",
     "tiles = gv.tile_sources.OSM\n",
     "vectorfield = gv.VectorField((xs, ys, angle, mag), crs=crs)"
    ]

--- a/examples/gallery/matplotlib/wind_barbs_example.ipynb
+++ b/examples/gallery/matplotlib/wind_barbs_example.ipynb
@@ -1,0 +1,90 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import geoviews as gv\n",
+    "\n",
+    "gv.extension('matplotlib')\n",
+    "\n",
+    "gv.output(fig='svg', size=200)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lat = np.arange(60, 37.5, -2.5)\n",
+    "lon = np.arange(270, 292.5, 2.5)\n",
+    "uwnd = np.array(\n",
+    "    [\n",
+    "        [2, 0, -2, -2, -3, -3, -3, -2, -1],\n",
+    "        [2, 0, -2, -2, -2, -2, -2, -1, 1],\n",
+    "        [2, -1, -2, -2, -2, -1, 0, 1, 3],\n",
+    "        [3, 0, -3, -5, -5, -4, -4, -2, 0],\n",
+    "        [8, 4, 0, -3, -5, -6, -6, -6, -5],\n",
+    "        [12, 10, 8, 5, 3, 0, -2, -2, -2],\n",
+    "        [13, 14, 16, 16, 14, 12, 10, 9, 10],\n",
+    "        [13, 18, 22, 24, 25, 24, 23, 22, 23],\n",
+    "        [20, 25, 29, 32, 33, 32, 32, 33, 34],\n",
+    "    ]\n",
+    ")\n",
+    "vwwnd = np.array(\n",
+    "    [\n",
+    "        [3, 1, 0, -1, -1, 0, 1, 3, 4],\n",
+    "        [-2, -3, -3, -2, 0, 2, 4, 6, 8],\n",
+    "        [-6, -6, -4, -1, 2, 5, 7, 10, 12],\n",
+    "        [-12, -10, -6, -1, 4, 7, 10, 12, 14],\n",
+    "        [-17, -15, -10, -4, 2, 6, 9, 12, 16],\n",
+    "        [-20, -18, -14, -8, -2, 2, 5, 10, 16],\n",
+    "        [-17, -16, -13, -9, -6, -3, 1, 7, 15],\n",
+    "        [-11, -10, -8, -6, -6, -5, -2, 6, 15],\n",
+    "        [-5, -3, -2, -2, -4, -5, -2, 6, 15],\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "wind_barbs = gv.WindBarbs.from_uv((lon, lat, uwnd, vwwnd)).opts(\n",
+    "    fig_size=250, length=6.5, padding=1\n",
+    ")\n",
+    "coastline = gv.feature.coastline()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wind_barbs * coastline"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/geoviews/__init__.py
+++ b/geoviews/__init__.py
@@ -11,7 +11,7 @@ from .element import ( # noqa (API import)
     _Element, Feature, Tiles, WMTS, LineContours, FilledContours,
     Text, Image, Points, Path, Polygons, Shape, Dataset, RGB,
     Contours, Graph, TriMesh, Nodes, EdgePaths, QuadMesh, VectorField,
-    HexTiles, Labels, Rectangles, Segments
+    HexTiles, Labels, Rectangles, Segments, WindBarbs
 )
 from .util import load_tiff, from_xarray # noqa (API import)
 from .operation import project                      # noqa (API import)

--- a/geoviews/element/__init__.py
+++ b/geoviews/element/__init__.py
@@ -7,7 +7,7 @@ from .geo import (_Element, Feature, Tiles, is_geographic,     # noqa (API impor
                   WMTS, Points, Image, Text, LineContours, RGB,
                   FilledContours, Path, Polygons, Shape, Dataset,
                   Contours, TriMesh, Graph, Nodes, EdgePaths, QuadMesh,
-                  VectorField, Labels, HexTiles, Rectangles, Segments)
+                  VectorField, Labels, HexTiles, Rectangles, Segments, WindBarbs)
 
 
 class GeoConversion(ElementConversion):

--- a/geoviews/element/comparison.py
+++ b/geoviews/element/comparison.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 
 from holoviews.element.comparison import Comparison as HvComparison
 
-from .geo import Image, Points, LineContours, FilledContours
+from .geo import Image, Points, LineContours, FilledContours, WindBarbs
 
 class Comparison(HvComparison):
 
@@ -13,6 +13,7 @@ class Comparison(HvComparison):
         cls.equality_type_funcs[Points] = cls.compare_dataset
         cls.equality_type_funcs[LineContours] = cls.compare_dataset
         cls.equality_type_funcs[FilledContours] = cls.compare_dataset
+        cls.equality_type_funcs[WindBarbs] = cls.compare_dataset
         return cls.equality_type_funcs
 
 

--- a/geoviews/element/geo.py
+++ b/geoviews/element/geo.py
@@ -363,17 +363,19 @@ class WindBarbs(_Element, Selection2DExpr, HvGeometry):
         radians = np.pi / 2 - np.arctan2(-vs, -us)
 
         if isinstance(data, tuple):
-            transformed_data = (xs, ys, radians, uv_magnitudes)
+            reorganized_data = (xs, ys, radians, uv_magnitudes)
         else:
-            transformed_data = {}
+            # calculations on this data could mutate the original data
+            # here we do not do any calculations; we only store the data
+            reorganized_data = {}
             for kdim in kdims:
-                transformed_data[kdim] = data[kdim]
-            transformed_data["Angle"] = radians
-            transformed_data["Magnitude"] = uv_magnitudes
+                reorganized_data[kdim] = data[kdim]
+            reorganized_data["Angle"] = radians
+            reorganized_data["Magnitude"] = uv_magnitudes
             for vdim in vdims[2:]:
-                transformed_data[vdim] = data[vdim]
+                reorganized_data[vdim] = data[vdim]
             vdims = ["Angle", "Magnitude"] + vdims[2:]
-        return cls(transformed_data, kdims=kdims, vdims=vdims, **params)
+        return cls(reorganized_data, kdims=kdims, vdims=vdims, **params)
 
 
 class Image(_Element, HvImage):

--- a/geoviews/element/geo.py
+++ b/geoviews/element/geo.py
@@ -351,6 +351,30 @@ class WindBarbs(_Element, Selection2DExpr, HvGeometry):
     vdims = param.List(default=[Dimension('Angle', cyclic=True, range=(0,2*np.pi)),
                                 Dimension('Magnitude')], bounds=(2, None))
 
+    @classmethod
+    def from_uv(cls, data, kdims=None, vdims=None, **params):
+        if isinstance(data, tuple):
+            xs, ys, us, vs = data
+        else:
+            us = data[vdims[0]]
+            vs = data[vdims[1]]
+
+        uv_magnitudes = np.hypot(us, vs)  # unscaled
+        radians = np.arctan2(-us, -vs)
+
+        if isinstance(data, tuple):
+            transformed_data = (xs, ys, radians, uv_magnitudes)
+        else:
+            transformed_data = {}
+            for kdim in kdims:
+                transformed_data[kdim] = data[kdim]
+            transformed_data["Angle"] = radians
+            transformed_data["Magnitude"] = uv_magnitudes
+            for vdim in vdims[2:]:
+                transformed_data[vdim] = data[vdim]
+            vdims = ["Angle", "Magnitude"] + vdims[2:]
+        return cls(transformed_data, kdims=kdims, vdims=vdims, **params)
+
 
 class Image(_Element, HvImage):
     """

--- a/geoviews/element/geo.py
+++ b/geoviews/element/geo.py
@@ -360,7 +360,7 @@ class WindBarbs(_Element, Selection2DExpr, HvGeometry):
             vs = data[vdims[1]]
 
         uv_magnitudes = np.hypot(us, vs)  # unscaled
-        radians = np.arctan2(-us, -vs)
+        radians = np.pi / 2 - np.arctan2(-vs, -us)
 
         if isinstance(data, tuple):
             transformed_data = (xs, ys, radians, uv_magnitudes)

--- a/geoviews/element/geo.py
+++ b/geoviews/element/geo.py
@@ -15,8 +15,10 @@ from holoviews.element import (
     QuadMesh as HvQuadMesh, Points as HvPoints,
     VectorField as HvVectorField, HexTiles as HvHexTiles,
     Labels as HvLabels, Rectangles as HvRectangles,
-    Segments as HvSegments
+    Segments as HvSegments, Geometry as HvGeometry,
 )
+from holoviews.element.selection import Selection2DExpr
+
 
 from shapely.geometry.base import BaseGeometry
 from shapely.geometry import (
@@ -335,6 +337,16 @@ class VectorField(_Element, HvVectorField):
     """
 
     group = param.String(default='VectorField', constant=True)
+
+    vdims = param.List(default=[Dimension('Angle', cyclic=True, range=(0,2*np.pi)),
+                                Dimension('Magnitude')], bounds=(1, None))
+
+
+class WindBarbs(_Element, Selection2DExpr, HvGeometry):
+    """
+    """
+    
+    group = param.String(default='WindBarbs', constant=True)
 
     vdims = param.List(default=[Dimension('Angle', cyclic=True, range=(0,2*np.pi)),
                                 Dimension('Magnitude')], bounds=(1, None))

--- a/geoviews/element/geo.py
+++ b/geoviews/element/geo.py
@@ -348,8 +348,7 @@ class WindBarbs(_Element, Selection2DExpr, HvGeometry):
     
     group = param.String(default='WindBarbs', constant=True)
 
-    vdims = param.List(default=[Dimension('Angle', cyclic=True, range=(0,2*np.pi)),
-                                Dimension('Magnitude')], bounds=(1, None))
+    vdims = param.List(default=[Dimension('U'), Dimension('V')], bounds=(2, None))
 
 
 class Image(_Element, HvImage):

--- a/geoviews/element/geo.py
+++ b/geoviews/element/geo.py
@@ -345,7 +345,7 @@ class VectorField(_Element, HvVectorField):
 class WindBarbs(_Element, Selection2DExpr, HvGeometry):
     """
     """
-    
+
     group = param.String(default='WindBarbs', constant=True)
 
     vdims = param.List(default=[Dimension('Angle', cyclic=True, range=(0,2*np.pi)),

--- a/geoviews/element/geo.py
+++ b/geoviews/element/geo.py
@@ -348,7 +348,8 @@ class WindBarbs(_Element, Selection2DExpr, HvGeometry):
     
     group = param.String(default='WindBarbs', constant=True)
 
-    vdims = param.List(default=[Dimension('U'), Dimension('V')], bounds=(2, None))
+    vdims = param.List(default=[Dimension('Angle', cyclic=True, range=(0,2*np.pi)),
+                                Dimension('Magnitude')], bounds=(2, None))
 
 
 class Image(_Element, HvImage):

--- a/geoviews/plotting/mpl/__init__.py
+++ b/geoviews/plotting/mpl/__init__.py
@@ -30,7 +30,7 @@ from ...element import (
     Image, Points, Feature, WMTS, Tiles, Text, LineContours,
     FilledContours, is_geographic, Path, Polygons, Shape, RGB,
     Contours, Nodes, EdgePaths, Graph, TriMesh, QuadMesh, VectorField,
-    HexTiles, Labels, Rectangles, Segments
+    HexTiles, Labels, Rectangles, Segments, WindBarbs
 )
 from ...util import geo_mesh, poly_types
 from ..plot import ProjectionPlot
@@ -39,6 +39,7 @@ from ...operation import (
     project_points, project_path, project_graph, project_quadmesh,
     project_geom
 )
+from .chart import WindBarbsPlot
 
 
 
@@ -327,6 +328,16 @@ class GeoVectorFieldPlot(GeoPlot, VectorFieldPlot):
     _project_operation = project_points
 
 
+class GeoWindBarbsPlot(GeoPlot, WindBarbsPlot):
+    """
+    Draws a wind barbs plot from the data in a WindBarbs Element.
+    """
+
+    apply_ranges = param.Boolean(default=True)
+
+    _project_operation = project_points
+
+
 class GeometryPlot(GeoPlot):
 
     def init_artists(self, ax, plot_args, plot_kwargs):
@@ -567,6 +578,7 @@ Store.register({LineContours: LineContourPlot,
                 Points: GeoPointPlot,
                 Labels: GeoLabelsPlot,
                 VectorField: GeoVectorFieldPlot,
+                WindBarbs: GeoWindBarbsPlot,
                 Text: GeoTextPlot,
                 Layout: LayoutPlot,
                 NdLayout: LayoutPlot,

--- a/geoviews/plotting/mpl/chart.py
+++ b/geoviews/plotting/mpl/chart.py
@@ -22,62 +22,18 @@ class WindBarbsPlot(ColorbarPlot):
     to the minimum distance respectively.
     """
 
-    arrow_heads = param.Boolean(
-        default=True,
-        doc="""
-       Whether or not to draw arrow heads. If arrowheads are enabled,
-       they may be customized with the 'headlength' and
-       'headaxislength' style options.""",
-    )
+    rounding = param.Boolean(default=True, doc="""
+        Whether the vector magnitude should be rounded when allocating
+        barb components.""")
 
-    magnitude = param.ClassSelector(
-        class_=(str, dim),
-        doc="""
-        Dimension or dimension value transform that declares the magnitude
-        of each vector. Magnitude is expected to be scaled between 0-1,
-        by default the magnitudes are rescaled relative to the minimum
-        distance between vectors, this can be disabled with the
-        rescale_lengths option.""",
-    )
+    barb_increments = param.Dict(default=None, doc="""
+        A dictionary of increments specifying values to associate
+        with different parts of the barb.""")
+
+    flip_barb = param.Parameter(default=False, doc="""
+        Whether the lines and flags should point opposite to normal.""")
 
     padding = param.ClassSelector(default=0.05, class_=(int, float, tuple))
-
-    rescale_lengths = param.Boolean(
-        default=True,
-        doc="""
-       Whether the lengths will be rescaled to take into account the
-       smallest non-zero distance between two vectors.""",
-    )
-
-    # Deprecated parameters
-
-    color_index = param.ClassSelector(
-        default=None,
-        class_=(str, int),
-        allow_None=True,
-        doc="""
-        Deprecated in favor of dimension value transform on color option,
-        e.g. `color=dim('Magnitude')`.
-        """,
-    )
-
-    size_index = param.ClassSelector(
-        default=None,
-        class_=(str, int),
-        allow_None=True,
-        doc="""
-        Deprecated in favor of the magnitude option, e.g.
-        `magnitude=dim('Magnitude')`.
-        """,
-    )
-
-    normalize_lengths = param.Boolean(
-        default=True,
-        doc="""
-        Deprecated in favor of rescaling length using dimension value
-        transforms using the magnitude option, e.g.
-        `dim('Magnitude').norm()`.""",
-    )
 
     style_opts = [
         "alpha",
@@ -88,12 +44,11 @@ class WindBarbsPlot(ColorbarPlot):
         "marker",
         "visible",
         "cmap",
-        "scale",
-        "headlength",
-        "headaxislength",
+        "length",
+        "barbcolor",
+        "flagcolor",
         "pivot",
         "width",
-        "headwidth",
         "norm",
     ]
 
@@ -104,36 +59,9 @@ class WindBarbsPlot(ColorbarPlot):
         "visible",
         "norm",
         "pivot",
-        "headlength",
-        "headaxislength",
-        "headwidth",
     ]
 
-    _plot_methods = dict(single="quiver")
-
-    def _get_magnitudes(self, element, style, ranges):
-        size_dim = element.get_dimension(self.size_index)
-        mag_dim = self.magnitude
-        if size_dim and mag_dim:
-            self.param.warning(
-                "Cannot declare style mapping for 'magnitude' option "
-                "and declare a size_index; ignoring the size_index."
-            )
-        elif size_dim:
-            mag_dim = size_dim
-        elif isinstance(mag_dim, str):
-            mag_dim = element.get_dimension(mag_dim)
-        if mag_dim is not None:
-            if isinstance(mag_dim, dim):
-                magnitudes = mag_dim.apply(element, flat=True)
-            else:
-                magnitudes = element.dimension_values(mag_dim)
-                _, max_magnitude = ranges[dimension_name(mag_dim)]["combined"]
-                if self.normalize_lengths and max_magnitude != 0:
-                    magnitudes = magnitudes / max_magnitude
-        else:
-            magnitudes = np.ones(len(element))
-        return magnitudes
+    _plot_methods = dict(single="barbs")
 
     def get_data(self, element, ranges, style):
         # Compute coordinates
@@ -141,44 +69,17 @@ class WindBarbsPlot(ColorbarPlot):
         xs = element.dimension_values(xidx) if len(element.data) else []
         ys = element.dimension_values(yidx) if len(element.data) else []
 
-        # Compute vector angle and magnitude
-        radians = element.dimension_values(2) if len(element.data) else []
-        if self.invert_axes:
-            radians = radians + 1.5 * np.pi
-        angles = list(np.rad2deg(radians))
-        magnitudes = self._get_magnitudes(element, style, ranges)
-        input_scale = style.pop("scale", 1.0)
-
-        args = (xs, ys, magnitudes, [0.0] * len(element))
-
-        # Compute color
-        cdim = element.get_dimension(self.color_index)
-        color = style.get("color", None)
-        if cdim and (
-            (isinstance(color, str) and color in element) or isinstance(color, dim)
-        ):
-            self.param.warning(
-                "Cannot declare style mapping for 'color' option and "
-                "declare a color_index; ignoring the color_index."
-            )
-            cdim = None
-        if cdim:
-            colors = element.dimension_values(self.color_index)
-            style["c"] = colors
-            cdim = element.get_dimension(self.color_index)
-            self._norm_kwargs(element, ranges, style, cdim)
-            style.pop("color", None)
+        us = element.dimension_values(2)
+        vs = element.dimension_values(3)
+        args = (xs, ys, us, vs)
 
         # Process style
-        style.update(dict(scale=input_scale, angles=angles, units="x", scale_units="x"))
         if "vmin" in style:
             style["clim"] = (style.pop("vmin"), style.pop("vmax"))
         if "c" in style:
             style["array"] = style.pop("c")
         if "pivot" not in style:
-            style["pivot"] = "mid"
-        if not self.arrow_heads:
-            style["headaxislength"] = 0
+            style["pivot"] = "tip"
 
         return args, style, {}
 
@@ -186,17 +87,16 @@ class WindBarbsPlot(ColorbarPlot):
         args, style, axis_kwargs = self.get_data(element, ranges, style)
 
         # Set magnitudes, angles and colors if supplied.
-        quiver = self.handles["artist"]
-        quiver.set_offsets(np.column_stack(args[:2]))
-        quiver.U = args[2]
-        quiver.angles = style["angles"]
+        barbs = self.handles["artist"]
+        barbs.set_offsets(np.column_stack(args[:2]))
+        barbs.angles = style["angles"]
         if "color" in style:
-            quiver.set_facecolors(style["color"])
-            quiver.set_edgecolors(style["color"])
+            barbs.set_facecolors(style["color"])
+            barbs.set_edgecolors(style["color"])
         if "array" in style:
-            quiver.set_array(style["array"])
+            barbs.set_array(style["array"])
         if "clim" in style:
-            quiver.set_clim(style["clim"])
+            barbs.set_clim(style["clim"])
         if "linewidth" in style:
-            quiver.set_linewidths(style["linewidth"])
+            barbs.set_linewidths(style["linewidth"])
         return axis_kwargs

--- a/geoviews/plotting/mpl/chart.py
+++ b/geoviews/plotting/mpl/chart.py
@@ -3,26 +3,32 @@ import numpy as np
 from holoviews.plotting.mpl.element import ColorbarPlot
 from holoviews.util.transform import dim
 from holoviews.core.dimension import dimension_name
+from holoviews.plotting.util import get_min_distance
+from holoviews.core.options import Store, abbreviated_exception
 
 
 class WindBarbsPlot(ColorbarPlot):
     """
-    Renders vector fields in sheet coordinates. The vectors are
-    expressed in polar coordinates and may be displayed according to
-    angle alone (with some common, arbitrary arrow length) or may be
-    true polar vectors.
+    Barbs are traditionally used in meteorology as a way to plot the speed and
+    direction of wind observations, but can technically be used to plot any two
+    dimensional vector quantity. As opposed to arrows, which give vector
+    magnitude by the length of the arrow, the barbs give more quantitative
+    information about the vector magnitude by putting slanted lines or a
+    triangle for various increments in magnitude.
 
-    The color or magnitude can be mapped onto any dimension using the
-    color_index and size_index.
-
-    The length of the arrows is controlled by the 'scale' style
-    option. The scaling of the arrows may also be controlled via the
-    normalize_lengths and rescale_lengths plot option, which will
-    normalize the lengths to a maximum of 1 and scale them according
-    to the minimum distance respectively.
+    The largest increment is given by a triangle (or "flag"). After those come full lines (barbs).
+    The smallest increment is a half line. There is only, of course, ever at most 1 half line.
+    If the magnitude is small and only needs a single half-line and no full lines or
+    triangles, the half-line is offset from the end of the barb so that it can be
+    easily distinguished from barbs with a single full line. The magnitude for the barb
+    shown above would nominally be 65, using the standard increments of 50, 10, and 5.
     """
 
     padding = param.ClassSelector(default=0.05, class_=(int, float, tuple))
+
+    from_uv_components = param.Boolean(default=False, doc="""
+        If True, the vdims are expected to be in the form of
+        wind components (U and V); else, wind direction and speed.""")
 
     style_opts = [
         "alpha",
@@ -68,17 +74,56 @@ class WindBarbsPlot(ColorbarPlot):
 
     _plot_methods = dict(single="barbs")
 
+
+    def _get_us_vs(self, element, style, ranges):
+        mag_dim = self.magnitude
+        if self.from_uv_components:
+            us = element.dimension_values(2, flat=False) if len(element.data) else []
+            vs = element.dimension_values(3, flat=False) if len(element.data) else []
+            uv_magnitudes = np.hypot(us, vs)  # unscaled
+            radians = (np.pi / 2.0) - np.arctan2(us / uv_magnitudes, vs / uv_magnitudes)
+            element = element.add_dimension("Angle", 4, radians, vdim=True)
+            element = element.add_dimension("Magnitude", 5, uv_magnitudes, vdim=True)
+            if mag_dim is None:
+                mag_dim = element.get_dimension(5)
+        else:
+            radians = element.dimension_values(2) if len(element.data) else []
+            if mag_dim is None:
+                mag_dim = element.get_dimension(3)
+
+        if isinstance(mag_dim, str):
+            mag_dim = element.get_dimension(mag_dim)
+
+        if isinstance(mag_dim, dim):
+            magnitudes = mag_dim.apply(element, flat=True)
+        else:
+            magnitudes = element.dimension_values(mag_dim)
+
+        if self.invert_axes:
+            radians += 1.5 * np.pi
+
+        # Compute U, V to serialize to matplotlib
+        # Even if it's from U, V components, we still need to re-compute
+        # because operations may have been applied to magnitudes
+        if not self.from_uv_components or isinstance(mag_dim, dim):
+            us = magnitudes * np.cos(radians.flatten())
+            vs = magnitudes * np.sin(radians.flatten())
+
+        return us, vs
+
     def get_data(self, element, ranges, style):
         # Compute coordinates
         xidx, yidx = (1, 0) if self.invert_axes else (0, 1)
         xs = element.dimension_values(xidx) if len(element.data) else []
         ys = element.dimension_values(yidx) if len(element.data) else []
 
-        us = element.dimension_values(2)
-        vs = element.dimension_values(3)
+        # Compute vector angle and magnitude
+        us, vs = self._get_us_vs(element, style, ranges)
         args = (xs, ys, us, vs)
 
         # Process style
+        with abbreviated_exception():
+            style = self._apply_transforms(element, ranges, style)
         if "vmin" in style:
             style["clim"] = (style.pop("vmin"), style.pop("vmax"))
         if "c" in style:
@@ -94,7 +139,6 @@ class WindBarbsPlot(ColorbarPlot):
         # Set magnitudes, angles and colors if supplied.
         barbs = self.handles["artist"]
         barbs.set_offsets(np.column_stack(args[:2]))
-        barbs.angles = style["angles"]
         if "color" in style:
             barbs.set_facecolors(style["color"])
             barbs.set_edgecolors(style["color"])

--- a/geoviews/plotting/mpl/chart.py
+++ b/geoviews/plotting/mpl/chart.py
@@ -22,17 +22,6 @@ class WindBarbsPlot(ColorbarPlot):
     to the minimum distance respectively.
     """
 
-    rounding = param.Boolean(default=True, doc="""
-        Whether the vector magnitude should be rounded when allocating
-        barb components.""")
-
-    barb_increments = param.Dict(default=None, doc="""
-        A dictionary of increments specifying values to associate
-        with different parts of the barb.""")
-
-    flip_barb = param.Parameter(default=False, doc="""
-        Whether the lines and flags should point opposite to normal.""")
-
     padding = param.ClassSelector(default=0.05, class_=(int, float, tuple))
 
     style_opts = [
@@ -44,12 +33,18 @@ class WindBarbsPlot(ColorbarPlot):
         "marker",
         "visible",
         "cmap",
+        "norm",
+        # barb specific
         "length",
         "barbcolor",
         "flagcolor",
+        "fill_empty",
+        "rounding",
+        "barb_increments",
+        "flip_barb",
         "pivot",
+        "sizes",
         "width",
-        "norm",
     ]
 
     _nonvectorized_styles = [
@@ -58,7 +53,17 @@ class WindBarbsPlot(ColorbarPlot):
         "cmap",
         "visible",
         "norm",
+        # TODO: clarify whether these are vectorized or not
+        "length",
+        "barbcolor",
+        "flagcolor",
+        "fill_empty",
+        "rounding",
+        "barb_increments",
+        "flip_barb",
         "pivot",
+        "sizes",
+        "width",
     ]
 
     _plot_methods = dict(single="barbs")

--- a/geoviews/plotting/mpl/chart.py
+++ b/geoviews/plotting/mpl/chart.py
@@ -2,9 +2,7 @@ import param
 import numpy as np
 from holoviews.plotting.mpl.element import ColorbarPlot
 from holoviews.util.transform import dim
-from holoviews.core.dimension import dimension_name
-from holoviews.plotting.util import get_min_distance
-from holoviews.core.options import Store, abbreviated_exception
+from holoviews.core.options import abbreviated_exception
 
 
 class WindBarbsPlot(ColorbarPlot):

--- a/geoviews/plotting/mpl/chart.py
+++ b/geoviews/plotting/mpl/chart.py
@@ -1,0 +1,202 @@
+import param
+import numpy as np
+from holoviews.plotting.mpl.element import ColorbarPlot
+from holoviews.util.transform import dim
+from holoviews.core.dimension import dimension_name
+
+
+class WindBarbsPlot(ColorbarPlot):
+    """
+    Renders vector fields in sheet coordinates. The vectors are
+    expressed in polar coordinates and may be displayed according to
+    angle alone (with some common, arbitrary arrow length) or may be
+    true polar vectors.
+
+    The color or magnitude can be mapped onto any dimension using the
+    color_index and size_index.
+
+    The length of the arrows is controlled by the 'scale' style
+    option. The scaling of the arrows may also be controlled via the
+    normalize_lengths and rescale_lengths plot option, which will
+    normalize the lengths to a maximum of 1 and scale them according
+    to the minimum distance respectively.
+    """
+
+    arrow_heads = param.Boolean(
+        default=True,
+        doc="""
+       Whether or not to draw arrow heads. If arrowheads are enabled,
+       they may be customized with the 'headlength' and
+       'headaxislength' style options.""",
+    )
+
+    magnitude = param.ClassSelector(
+        class_=(str, dim),
+        doc="""
+        Dimension or dimension value transform that declares the magnitude
+        of each vector. Magnitude is expected to be scaled between 0-1,
+        by default the magnitudes are rescaled relative to the minimum
+        distance between vectors, this can be disabled with the
+        rescale_lengths option.""",
+    )
+
+    padding = param.ClassSelector(default=0.05, class_=(int, float, tuple))
+
+    rescale_lengths = param.Boolean(
+        default=True,
+        doc="""
+       Whether the lengths will be rescaled to take into account the
+       smallest non-zero distance between two vectors.""",
+    )
+
+    # Deprecated parameters
+
+    color_index = param.ClassSelector(
+        default=None,
+        class_=(str, int),
+        allow_None=True,
+        doc="""
+        Deprecated in favor of dimension value transform on color option,
+        e.g. `color=dim('Magnitude')`.
+        """,
+    )
+
+    size_index = param.ClassSelector(
+        default=None,
+        class_=(str, int),
+        allow_None=True,
+        doc="""
+        Deprecated in favor of the magnitude option, e.g.
+        `magnitude=dim('Magnitude')`.
+        """,
+    )
+
+    normalize_lengths = param.Boolean(
+        default=True,
+        doc="""
+        Deprecated in favor of rescaling length using dimension value
+        transforms using the magnitude option, e.g.
+        `dim('Magnitude').norm()`.""",
+    )
+
+    style_opts = [
+        "alpha",
+        "color",
+        "edgecolors",
+        "facecolors",
+        "linewidth",
+        "marker",
+        "visible",
+        "cmap",
+        "scale",
+        "headlength",
+        "headaxislength",
+        "pivot",
+        "width",
+        "headwidth",
+        "norm",
+    ]
+
+    _nonvectorized_styles = [
+        "alpha",
+        "marker",
+        "cmap",
+        "visible",
+        "norm",
+        "pivot",
+        "headlength",
+        "headaxislength",
+        "headwidth",
+    ]
+
+    _plot_methods = dict(single="quiver")
+
+    def _get_magnitudes(self, element, style, ranges):
+        size_dim = element.get_dimension(self.size_index)
+        mag_dim = self.magnitude
+        if size_dim and mag_dim:
+            self.param.warning(
+                "Cannot declare style mapping for 'magnitude' option "
+                "and declare a size_index; ignoring the size_index."
+            )
+        elif size_dim:
+            mag_dim = size_dim
+        elif isinstance(mag_dim, str):
+            mag_dim = element.get_dimension(mag_dim)
+        if mag_dim is not None:
+            if isinstance(mag_dim, dim):
+                magnitudes = mag_dim.apply(element, flat=True)
+            else:
+                magnitudes = element.dimension_values(mag_dim)
+                _, max_magnitude = ranges[dimension_name(mag_dim)]["combined"]
+                if self.normalize_lengths and max_magnitude != 0:
+                    magnitudes = magnitudes / max_magnitude
+        else:
+            magnitudes = np.ones(len(element))
+        return magnitudes
+
+    def get_data(self, element, ranges, style):
+        # Compute coordinates
+        xidx, yidx = (1, 0) if self.invert_axes else (0, 1)
+        xs = element.dimension_values(xidx) if len(element.data) else []
+        ys = element.dimension_values(yidx) if len(element.data) else []
+
+        # Compute vector angle and magnitude
+        radians = element.dimension_values(2) if len(element.data) else []
+        if self.invert_axes:
+            radians = radians + 1.5 * np.pi
+        angles = list(np.rad2deg(radians))
+        magnitudes = self._get_magnitudes(element, style, ranges)
+        input_scale = style.pop("scale", 1.0)
+
+        args = (xs, ys, magnitudes, [0.0] * len(element))
+
+        # Compute color
+        cdim = element.get_dimension(self.color_index)
+        color = style.get("color", None)
+        if cdim and (
+            (isinstance(color, str) and color in element) or isinstance(color, dim)
+        ):
+            self.param.warning(
+                "Cannot declare style mapping for 'color' option and "
+                "declare a color_index; ignoring the color_index."
+            )
+            cdim = None
+        if cdim:
+            colors = element.dimension_values(self.color_index)
+            style["c"] = colors
+            cdim = element.get_dimension(self.color_index)
+            self._norm_kwargs(element, ranges, style, cdim)
+            style.pop("color", None)
+
+        # Process style
+        style.update(dict(scale=input_scale, angles=angles, units="x", scale_units="x"))
+        if "vmin" in style:
+            style["clim"] = (style.pop("vmin"), style.pop("vmax"))
+        if "c" in style:
+            style["array"] = style.pop("c")
+        if "pivot" not in style:
+            style["pivot"] = "mid"
+        if not self.arrow_heads:
+            style["headaxislength"] = 0
+
+        return args, style, {}
+
+    def update_handles(self, key, axis, element, ranges, style):
+        args, style, axis_kwargs = self.get_data(element, ranges, style)
+
+        # Set magnitudes, angles and colors if supplied.
+        quiver = self.handles["artist"]
+        quiver.set_offsets(np.column_stack(args[:2]))
+        quiver.U = args[2]
+        quiver.angles = style["angles"]
+        if "color" in style:
+            quiver.set_facecolors(style["color"])
+            quiver.set_edgecolors(style["color"])
+        if "array" in style:
+            quiver.set_array(style["array"])
+        if "clim" in style:
+            quiver.set_clim(style["clim"])
+        if "linewidth" in style:
+            quiver.set_linewidths(style["linewidth"])
+        return axis_kwargs

--- a/geoviews/tests/plotting/mpl/test_chart.py
+++ b/geoviews/tests/plotting/mpl/test_chart.py
@@ -1,0 +1,174 @@
+import numpy as np
+import xarray as xr
+import geoviews as gv
+
+from geoviews.element import WindBarbs
+
+from holoviews.tests.plotting.matplotlib.test_plot import TestMPLPlot
+from holoviews.tests.plotting.utils import ParamLogStream
+
+from geoviews import Store
+
+gv.extension("matplotlib")
+mpl_renderer = Store.renderers["matplotlib"]
+
+
+class TestWindBarbsPlot(TestMPLPlot):
+    def test_windbarbs(self):
+        x = np.linspace(-1, 1, 4)
+        X, Y = np.meshgrid(x, x)
+        U, V = 10 * X, 0 * Y
+
+        mag = np.sqrt(U**2 + V**2)
+        angle = (np.pi / 2.0) - np.arctan2(U / mag, V / mag)
+
+        gv_barbs = WindBarbs((X, Y, angle, mag))
+
+        fig = gv.render(gv_barbs)
+        mpl_barbs = fig.axes[0].get_children()[0]
+        np.testing.assert_almost_equal(mpl_barbs.u.data, U.T.flatten())
+        np.testing.assert_almost_equal(mpl_barbs.v.data, V.flatten())
+
+    def test_windbarbs_dataset(self):
+        x = np.linspace(-1, 1, 4)
+        X, Y = np.meshgrid(x, x)
+        U, V = 10 * X, 0 * Y
+
+        mag = np.sqrt(U**2 + V**2)
+        angle = (np.pi / 2.0) - np.arctan2(U / mag, V / mag)
+
+        xr.Dataset(
+            {
+                "u": (["y", "x"], U),
+                "v": (["y", "x"], V),
+                "ang": (["x", "y"], angle),
+                "mag": (["x", "y"], mag),
+            },
+            coords={"x": X[:, 0], "y": Y[0, :]},
+        )
+
+        gv_barbs = WindBarbs((X, Y, angle, mag))
+        fig = gv.render(gv_barbs)
+        mpl_barbs = fig.axes[0].get_children()[0]
+        np.testing.assert_almost_equal(mpl_barbs.u.data, U.T.flatten())
+        np.testing.assert_almost_equal(mpl_barbs.v.data, V.flatten())
+
+    def test_windbarbs_from_uv_components(self):
+        x = np.linspace(-1, 1, 4)
+        X, Y = np.meshgrid(x, x)
+        U, V = 10 * X, 0 * Y
+
+        gv_barbs = WindBarbs((X, Y, U, V)).opts(from_uv_components=True)
+
+        fig = gv.render(gv_barbs)
+        mpl_barbs = fig.axes[0].get_children()[0]
+        np.testing.assert_almost_equal(mpl_barbs.u.data, U.flatten())
+        np.testing.assert_almost_equal(mpl_barbs.v.data, V.flatten())
+
+    def test_windbarbs_color_op(self):
+        barbs = WindBarbs(
+            [(0, 0, 0, 1, "#000000"), (0, 1, 0, 1, "#FF0000"), (0, 2, 0, 1, "#00FF00")],
+            vdims=["A", "M", "color"],
+        ).opts(color="color")
+        plot = mpl_renderer.get_plot(barbs)
+        artist = plot.handles["artist"]
+        self.assertEqual(
+            artist.get_facecolors(),
+            np.array([[0, 0, 0, 1], [1, 0, 0, 1], [0, 1, 0, 1]]),
+        )
+
+    def test_windbarbs_both_flagcolor_barbcolor(self):
+        x = np.linspace(-1, 1, 4)
+        X, Y = np.meshgrid(x, x)
+        U, V = 10 * X, 0 * Y
+
+        mag = np.sqrt(U**2 + V**2)
+        angle = (np.pi / 2.0) - np.arctan2(U / mag, V / mag)
+
+        barbs = gv.WindBarbs((X, Y, angle, mag)).opts(
+            colorbar=True, clim=(0, 50), flagcolor="red", barbcolor="blue"
+        )
+        plot = mpl_renderer.get_plot(barbs)
+        artist = plot.handles["artist"]
+        np.testing.assert_almost_equal(
+            # red
+            artist.get_facecolor(),
+            np.array([[1.0, 0.0, 0.0, 1.0]]),
+        )
+        np.testing.assert_almost_equal(
+            # blue
+            artist.get_edgecolor(),
+            np.array([[0.0, 0.0, 1.0, 1.0]]),
+        )
+
+    def test_windbarbs_flagcolor(self):
+        x = np.linspace(-1, 1, 4)
+        X, Y = np.meshgrid(x, x)
+        U, V = 10 * X, 0 * Y
+
+        mag = np.sqrt(U**2 + V**2)
+        angle = (np.pi / 2.0) - np.arctan2(U / mag, V / mag)
+
+        barbs = gv.WindBarbs((X, Y, angle, mag)).opts(
+            colorbar=True, clim=(0, 50), flagcolor="red"
+        )
+        plot = mpl_renderer.get_plot(barbs)
+        artist = plot.handles["artist"]
+        np.testing.assert_almost_equal(
+            # red (RGBA)
+            artist.get_facecolor(),
+            np.array([[1.0, 0.0, 0.0, 1.0]]),
+        )
+        np.testing.assert_almost_equal(
+            # red
+            artist.get_edgecolor(),
+            np.array([[1.0, 0.0, 0.0, 1.0]]),
+        )
+
+    def test_windbarbs_barbcolor(self):
+        x = np.linspace(-1, 1, 4)
+        X, Y = np.meshgrid(x, x)
+        U, V = 10 * X, 0 * Y
+
+        mag = np.sqrt(U**2 + V**2)
+        angle = (np.pi / 2.0) - np.arctan2(U / mag, V / mag)
+
+        barbs = gv.WindBarbs((X, Y, angle, mag)).opts(
+            colorbar=True, clim=(0, 50), barbcolor="red"
+        )
+        plot = mpl_renderer.get_plot(barbs)
+        artist = plot.handles["artist"]
+        np.testing.assert_almost_equal(
+            # red (RGBA)
+            artist.get_facecolor(),
+            np.array([[1.0, 0.0, 0.0, 1.0]]),
+        )
+        np.testing.assert_almost_equal(
+            # red
+            artist.get_edgecolor(),
+            np.array([[1.0, 0.0, 0.0, 1.0]]),
+        )
+
+    def test_windbarbs_color_warning(self):
+        x = np.linspace(-1, 1, 4)
+        X, Y = np.meshgrid(x, x)
+        U, V = 10 * X, 0 * Y
+
+        mag = np.sqrt(U**2 + V**2)
+        angle = (np.pi / 2.0) - np.arctan2(U / mag, V / mag)
+
+        barbs = gv.WindBarbs((X, Y, angle, mag)).opts(
+            colorbar=True,
+            clim=(0, 50),
+            color="Magnitude",
+            flagcolor="black",
+            barbcolor="black",
+        )
+        with ParamLogStream() as log:
+            mpl_renderer.get_plot(barbs)
+        log_msg = log.stream.read()
+        warning = (
+            "Cannot declare style mapping for 'color' option and either "
+            "'flagcolor' and 'barbcolor'; ignoring 'flagcolor' and 'barbcolor'.\n"
+        )
+        self.assertEqual(log_msg, warning)

--- a/geoviews/tests/plotting/mpl/test_chart.py
+++ b/geoviews/tests/plotting/mpl/test_chart.py
@@ -9,7 +9,6 @@ from holoviews.tests.plotting.utils import ParamLogStream
 
 from geoviews import Store
 
-gv.extension("matplotlib")
 mpl_renderer = Store.renderers["matplotlib"]
 
 
@@ -17,7 +16,7 @@ class TestWindBarbsPlot(TestMPLPlot):
     def test_windbarbs(self):
         x = np.linspace(-1, 1, 4)
         X, Y = np.meshgrid(x, x)
-        U, V = 10 * X, 0 * Y
+        U, V = 10 * X, 5 * Y
 
         angle = np.pi / 2 - np.arctan2(-V, -U)
         mag = np.hypot(U, V)
@@ -27,7 +26,7 @@ class TestWindBarbsPlot(TestMPLPlot):
         fig = gv.render(gv_barbs)
         mpl_barbs = fig.axes[0].get_children()[0]
         np.testing.assert_almost_equal(mpl_barbs.u.data, U.T.flatten())
-        # np.testing.assert_almost_equal(mpl_barbs.v.data, V.flatten())
+        np.testing.assert_almost_equal(mpl_barbs.v.data, V.flatten())
 
     def test_windbarbs_dataset(self):
         x = np.linspace(-1, 1, 4)

--- a/geoviews/tests/plotting/mpl/test_chart.py
+++ b/geoviews/tests/plotting/mpl/test_chart.py
@@ -19,7 +19,7 @@ class TestWindBarbsPlot(TestMPLPlot):
         X, Y = np.meshgrid(x, x)
         U, V = 10 * X, 0 * Y
 
-        angle = np.arctan2(-U, -V)
+        angle = np.pi / 2 - np.arctan2(-V, -U)
         mag = np.hypot(U, V)
 
         gv_barbs = WindBarbs((X, Y, angle, mag))
@@ -34,7 +34,7 @@ class TestWindBarbsPlot(TestMPLPlot):
         X, Y = np.meshgrid(x, x)
         U, V = 10 * X, 0 * Y
 
-        angle = np.arctan2(-U, -V)
+        angle = np.pi / 2 - np.arctan2(-V, -U)
         mag = np.hypot(U, V)
         ds = xr.Dataset(
             {
@@ -58,7 +58,7 @@ class TestWindBarbsPlot(TestMPLPlot):
         X, Y = np.meshgrid(x, x)
         U, V = 10 * X, 0 * Y
 
-        angle = np.arctan2(-U, -V)
+        angle = np.pi / 2 - np.arctan2(-V, -U)
         mag = np.hypot(U, V)
 
         gv_barbs = WindBarbs((X, Y, angle, mag))
@@ -72,7 +72,7 @@ class TestWindBarbsPlot(TestMPLPlot):
         X, Y = np.meshgrid(x, x)
         U, V = 10 * X, 0 * Y
 
-        angle = np.arctan2(-U, -V)
+        angle = np.pi / 2 - np.arctan2(-V, -U)
         mag = np.hypot(U, V)
         ds = xr.Dataset(
             {
@@ -105,7 +105,7 @@ class TestWindBarbsPlot(TestMPLPlot):
         X, Y = np.meshgrid(x, x)
         U, V = 10 * X, 0 * Y
 
-        angle = np.arctan2(-U, -V)
+        angle = np.pi / 2 - np.arctan2(-V, -U)
         mag = np.hypot(U, V)
 
         barbs = gv.WindBarbs((X, Y, angle, mag)).opts(
@@ -129,7 +129,7 @@ class TestWindBarbsPlot(TestMPLPlot):
         X, Y = np.meshgrid(x, x)
         U, V = 10 * X, 0 * Y
 
-        angle = np.arctan2(-U, -V)
+        angle = np.pi / 2 - np.arctan2(-V, -U)
         mag = np.hypot(U, V)
 
         barbs = gv.WindBarbs((X, Y, angle, mag)).opts(
@@ -153,7 +153,7 @@ class TestWindBarbsPlot(TestMPLPlot):
         X, Y = np.meshgrid(x, x)
         U, V = 10 * X, 0 * Y
 
-        angle = np.arctan2(-U, -V)
+        angle = np.pi / 2 - np.arctan2(-V, -U)
         mag = np.hypot(U, V)
 
         barbs = gv.WindBarbs((X, Y, angle, mag)).opts(
@@ -177,7 +177,7 @@ class TestWindBarbsPlot(TestMPLPlot):
         X, Y = np.meshgrid(x, x)
         U, V = 10 * X, 0 * Y
 
-        angle = np.arctan2(-U, -V)
+        angle = np.pi / 2 - np.arctan2(-V, -U)
         mag = np.hypot(U, V)
 
         barbs = gv.WindBarbs((X, Y, angle, mag)).opts(

--- a/geoviews/tests/plotting/mpl/test_chart.py
+++ b/geoviews/tests/plotting/mpl/test_chart.py
@@ -19,51 +19,74 @@ class TestWindBarbsPlot(TestMPLPlot):
         X, Y = np.meshgrid(x, x)
         U, V = 10 * X, 0 * Y
 
-        mag = np.sqrt(U**2 + V**2)
-        angle = (np.pi / 2.0) - np.arctan2(U / mag, V / mag)
+        angle = np.arctan2(-U, -V)
+        mag = np.hypot(U, V)
 
         gv_barbs = WindBarbs((X, Y, angle, mag))
 
         fig = gv.render(gv_barbs)
         mpl_barbs = fig.axes[0].get_children()[0]
         np.testing.assert_almost_equal(mpl_barbs.u.data, U.T.flatten())
-        np.testing.assert_almost_equal(mpl_barbs.v.data, V.flatten())
+        # np.testing.assert_almost_equal(mpl_barbs.v.data, V.flatten())
 
     def test_windbarbs_dataset(self):
         x = np.linspace(-1, 1, 4)
         X, Y = np.meshgrid(x, x)
         U, V = 10 * X, 0 * Y
 
-        mag = np.sqrt(U**2 + V**2)
-        angle = (np.pi / 2.0) - np.arctan2(U / mag, V / mag)
-
-        xr.Dataset(
+        angle = np.arctan2(-U, -V)
+        mag = np.hypot(U, V)
+        ds = xr.Dataset(
             {
                 "u": (["y", "x"], U),
                 "v": (["y", "x"], V),
-                "ang": (["x", "y"], angle),
-                "mag": (["x", "y"], mag),
+                "a": (["y", "x"], angle),
+                "m": (["y", "x"], mag),
             },
-            coords={"x": X[:, 0], "y": Y[0, :]},
+            coords={"x": x, "y": -x},
         )
 
-        gv_barbs = WindBarbs((X, Y, angle, mag))
+        gv_barbs = gv.WindBarbs(ds, ["x", "y"], ["a", "m"])
+
         fig = gv.render(gv_barbs)
         mpl_barbs = fig.axes[0].get_children()[0]
         np.testing.assert_almost_equal(mpl_barbs.u.data, U.T.flatten())
         np.testing.assert_almost_equal(mpl_barbs.v.data, V.flatten())
 
-    def test_windbarbs_from_uv_components(self):
+    def test_windbarbs_from_uv(self):
         x = np.linspace(-1, 1, 4)
         X, Y = np.meshgrid(x, x)
         U, V = 10 * X, 0 * Y
 
-        gv_barbs = WindBarbs((X, Y, U, V)).opts(from_uv_components=True)
+        angle = np.arctan2(-U, -V)
+        mag = np.hypot(U, V)
 
-        fig = gv.render(gv_barbs)
-        mpl_barbs = fig.axes[0].get_children()[0]
-        np.testing.assert_almost_equal(mpl_barbs.u.data, U.flatten())
-        np.testing.assert_almost_equal(mpl_barbs.v.data, V.flatten())
+        gv_barbs = WindBarbs((X, Y, angle, mag))
+        gv_barbs_uv = WindBarbs.from_uv((X, Y, U, V))
+
+        np.testing.assert_almost_equal(gv_barbs.data["Angle"], gv_barbs_uv.data["Angle"])
+        np.testing.assert_almost_equal(gv_barbs.data["Magnitude"], gv_barbs_uv.data["Magnitude"])
+
+    def test_windbarbs_dataset_from_uv_other_dim(self):
+        x = np.linspace(-1, 1, 4)
+        X, Y = np.meshgrid(x, x)
+        U, V = 10 * X, 0 * Y
+
+        angle = np.arctan2(-U, -V)
+        mag = np.hypot(U, V)
+        ds = xr.Dataset(
+            {
+                "u": (["y", "x"], U),
+                "v": (["y", "x"], V),
+                "a": (["y", "x"], angle),
+                "m": (["y", "x"], mag),
+                "other": (["y", "x"], np.ones_like(mag)),
+            },
+            coords={"x": x, "y": -x},
+        )
+
+        gv_barbs = WindBarbs.from_uv(ds, ["x", "y"], ["u", "v", "other"])
+        assert "other" in gv_barbs.data
 
     def test_windbarbs_color_op(self):
         barbs = WindBarbs(
@@ -82,8 +105,8 @@ class TestWindBarbsPlot(TestMPLPlot):
         X, Y = np.meshgrid(x, x)
         U, V = 10 * X, 0 * Y
 
-        mag = np.sqrt(U**2 + V**2)
-        angle = (np.pi / 2.0) - np.arctan2(U / mag, V / mag)
+        angle = np.arctan2(-U, -V)
+        mag = np.hypot(U, V)
 
         barbs = gv.WindBarbs((X, Y, angle, mag)).opts(
             colorbar=True, clim=(0, 50), flagcolor="red", barbcolor="blue"
@@ -106,8 +129,8 @@ class TestWindBarbsPlot(TestMPLPlot):
         X, Y = np.meshgrid(x, x)
         U, V = 10 * X, 0 * Y
 
-        mag = np.sqrt(U**2 + V**2)
-        angle = (np.pi / 2.0) - np.arctan2(U / mag, V / mag)
+        angle = np.arctan2(-U, -V)
+        mag = np.hypot(U, V)
 
         barbs = gv.WindBarbs((X, Y, angle, mag)).opts(
             colorbar=True, clim=(0, 50), flagcolor="red"
@@ -130,8 +153,8 @@ class TestWindBarbsPlot(TestMPLPlot):
         X, Y = np.meshgrid(x, x)
         U, V = 10 * X, 0 * Y
 
-        mag = np.sqrt(U**2 + V**2)
-        angle = (np.pi / 2.0) - np.arctan2(U / mag, V / mag)
+        angle = np.arctan2(-U, -V)
+        mag = np.hypot(U, V)
 
         barbs = gv.WindBarbs((X, Y, angle, mag)).opts(
             colorbar=True, clim=(0, 50), barbcolor="red"
@@ -154,8 +177,8 @@ class TestWindBarbsPlot(TestMPLPlot):
         X, Y = np.meshgrid(x, x)
         U, V = 10 * X, 0 * Y
 
-        mag = np.sqrt(U**2 + V**2)
-        angle = (np.pi / 2.0) - np.arctan2(U / mag, V / mag)
+        angle = np.arctan2(-U, -V)
+        mag = np.hypot(U, V)
 
         barbs = gv.WindBarbs((X, Y, angle, mag)).opts(
             colorbar=True,

--- a/geoviews/tests/plotting/mpl/test_chart.py
+++ b/geoviews/tests/plotting/mpl/test_chart.py
@@ -4,12 +4,12 @@ import geoviews as gv
 
 from geoviews.element import WindBarbs
 
-from holoviews.tests.plotting.matplotlib.test_plot import TestMPLPlot
 from holoviews.tests.plotting.utils import ParamLogStream
 
 from geoviews import Store
 
-gv.extension("matplotlib")
+from test_plot import TestMPLPlot
+
 mpl_renderer = Store.renderers["matplotlib"]
 
 

--- a/geoviews/tests/plotting/mpl/test_chart.py
+++ b/geoviews/tests/plotting/mpl/test_chart.py
@@ -32,7 +32,7 @@ class TestWindBarbsPlot(TestMPLPlot):
     def test_windbarbs_dataset(self):
         x = np.linspace(-1, 1, 4)
         X, Y = np.meshgrid(x, x)
-        U, V = 10 * X, 0 * Y
+        U, V = 10 * X, 1 * Y
 
         angle = np.pi / 2 - np.arctan2(-V, -U)
         mag = np.hypot(U, V)
@@ -56,7 +56,7 @@ class TestWindBarbsPlot(TestMPLPlot):
     def test_windbarbs_from_uv(self):
         x = np.linspace(-1, 1, 4)
         X, Y = np.meshgrid(x, x)
-        U, V = 10 * X, 0 * Y
+        U, V = 10 * X, 2 * Y
 
         angle = np.pi / 2 - np.arctan2(-V, -U)
         mag = np.hypot(U, V)
@@ -70,7 +70,7 @@ class TestWindBarbsPlot(TestMPLPlot):
     def test_windbarbs_dataset_from_uv_other_dim(self):
         x = np.linspace(-1, 1, 4)
         X, Y = np.meshgrid(x, x)
-        U, V = 10 * X, 0 * Y
+        U, V = 10 * X, 3 * Y
 
         angle = np.pi / 2 - np.arctan2(-V, -U)
         mag = np.hypot(U, V)
@@ -103,7 +103,7 @@ class TestWindBarbsPlot(TestMPLPlot):
     def test_windbarbs_both_flagcolor_barbcolor(self):
         x = np.linspace(-1, 1, 4)
         X, Y = np.meshgrid(x, x)
-        U, V = 10 * X, 0 * Y
+        U, V = 10 * X, 4 * Y
 
         angle = np.pi / 2 - np.arctan2(-V, -U)
         mag = np.hypot(U, V)
@@ -127,7 +127,7 @@ class TestWindBarbsPlot(TestMPLPlot):
     def test_windbarbs_flagcolor(self):
         x = np.linspace(-1, 1, 4)
         X, Y = np.meshgrid(x, x)
-        U, V = 10 * X, 0 * Y
+        U, V = 10 * X, 5 * Y
 
         angle = np.pi / 2 - np.arctan2(-V, -U)
         mag = np.hypot(U, V)
@@ -151,7 +151,7 @@ class TestWindBarbsPlot(TestMPLPlot):
     def test_windbarbs_barbcolor(self):
         x = np.linspace(-1, 1, 4)
         X, Y = np.meshgrid(x, x)
-        U, V = 10 * X, 0 * Y
+        U, V = 10 * X, 6 * Y
 
         angle = np.pi / 2 - np.arctan2(-V, -U)
         mag = np.hypot(U, V)
@@ -175,7 +175,7 @@ class TestWindBarbsPlot(TestMPLPlot):
     def test_windbarbs_color_warning(self):
         x = np.linspace(-1, 1, 4)
         X, Y = np.meshgrid(x, x)
-        U, V = 10 * X, 0 * Y
+        U, V = 10 * X, 7 * Y
 
         angle = np.pi / 2 - np.arctan2(-V, -U)
         mag = np.hypot(U, V)

--- a/geoviews/tests/plotting/mpl/test_chart.py
+++ b/geoviews/tests/plotting/mpl/test_chart.py
@@ -9,6 +9,7 @@ from holoviews.tests.plotting.utils import ParamLogStream
 
 from geoviews import Store
 
+gv.extension("matplotlib")
 mpl_renderer = Store.renderers["matplotlib"]
 
 
@@ -26,7 +27,7 @@ class TestWindBarbsPlot(TestMPLPlot):
         fig = gv.render(gv_barbs)
         mpl_barbs = fig.axes[0].get_children()[0]
         np.testing.assert_almost_equal(mpl_barbs.u.data, U.T.flatten())
-        np.testing.assert_almost_equal(mpl_barbs.v.data, V.flatten())
+        np.testing.assert_almost_equal(mpl_barbs.v.data, V.T.flatten())
 
     def test_windbarbs_dataset(self):
         x = np.linspace(-1, 1, 4)

--- a/geoviews/tests/plotting/mpl/test_chart.py
+++ b/geoviews/tests/plotting/mpl/test_chart.py
@@ -43,7 +43,7 @@ class TestWindBarbsPlot(TestMPLPlot):
                 "a": (["y", "x"], angle),
                 "m": (["y", "x"], mag),
             },
-            coords={"x": x, "y": -x},
+            coords={"x": x, "y": x},
         )
 
         gv_barbs = gv.WindBarbs(ds, ["x", "y"], ["a", "m"])
@@ -51,7 +51,7 @@ class TestWindBarbsPlot(TestMPLPlot):
         fig = gv.render(gv_barbs)
         mpl_barbs = fig.axes[0].get_children()[0]
         np.testing.assert_almost_equal(mpl_barbs.u.data, U.T.flatten())
-        np.testing.assert_almost_equal(mpl_barbs.v.data, V.flatten())
+        np.testing.assert_almost_equal(mpl_barbs.v.data, V.T.flatten())
 
     def test_windbarbs_from_uv(self):
         x = np.linspace(-1, 1, 4)

--- a/geoviews/tests/plotting/mpl/test_plot.py
+++ b/geoviews/tests/plotting/mpl/test_plot.py
@@ -1,0 +1,29 @@
+import matplotlib.pyplot as plt
+import pyviz_comms as comms
+
+from geoviews import Store
+from geoviews.element.comparison import ComparisonTestCase
+from geoviews.plotting.mpl import ElementPlot
+from param import concrete_descendents
+
+mpl_renderer = Store.renderers['matplotlib']
+
+
+class TestMPLPlot(ComparisonTestCase):
+
+    def setUp(self):
+        self.previous_backend = Store.current_backend
+        self.comm_manager = mpl_renderer.comm_manager
+        mpl_renderer.comm_manager = comms.CommManager
+        Store.set_current_backend('matplotlib')
+        self._padding = {}
+        for plot in concrete_descendents(ElementPlot).values():
+            self._padding[plot] = plot.padding
+            plot.padding = 0
+
+    def tearDown(self):
+        Store.current_backend = self.previous_backend
+        mpl_renderer.comm_manager = self.comm_manager
+        plt.close(plt.gcf())
+        for plot, padding in self._padding.items():
+            plot.padding = padding


### PR DESCRIPTION
Still working on it. Also, I'm still on the fence whether this should reside in GeoViews vs HoloViews.

Closes https://github.com/holoviz/geoviews/issues/133

Wondering if this should follow VectorField conventions (magnitude and angle) instead of U, V

I'm leaning towards U and V because in my experience dealing with atmospheric science data, files are always separated by zonal and meridional winds (U and V).

The downside of not following VectorField conventions is that users wont be able to swap out gv.Barbs for gv.VectorField directly.
