### PR TITLE
Add support for xyzservices

### DIFF
--- a/geoviews/element/geo.py
+++ b/geoviews/element/geo.py
@@ -209,10 +209,20 @@ class Feature(_GeoFeature):
 
 class WMTS(_GeoFeature):
     """
-    The WMTS Element represents a Web Map Tile Service specified as a
-    URL containing {x}, {y}, and {z} templating variables, e.g.:
+    The WMTS Element represents a Web Map Tile Service specified as URL
+    containing different template variables or xyzservices.TileProvider.
 
-    https://maps.wikimedia.org/osm-intl/{Z}/{X}/{Y}@2x.png
+    These variables correspond to three different formats for specifying the spatial
+    location and zoom level of the requested tiles:
+
+    * Web mapping tiles sources containing {x}, {y}, and {z} variables
+    * Bounding box tile sources containing {XMIN}, {XMAX}, {YMIN}, {YMAX} variables
+    * Quadkey tile sources containin a {Q} variable
+
+    Tiles are defined in a pseudo-Mercator projection (EPSG:3857)
+    defined as eastings and northings. Any data overlaid on a tile
+    source therefore has to be defined in those coordinates or be
+    projected.
     """
 
     crs = param.ClassSelector(default=ccrs.GOOGLE_MERCATOR, class_=ccrs.CRS, doc="""
@@ -230,11 +240,9 @@ class WMTS(_GeoFeature):
             data = data.url
         elif WebMapTileService and isinstance(data, WebMapTileService):
             pass
-        elif not isinstance(data, str):
-            raise TypeError(
-                f'{type(self).__name__} data should be a tile service '
-                f'URL not a {type(data).__name__} type.'
-            )
+        elif data is not None and not isinstance(data, (str, dict)):
+            raise TypeError('{} data should be a tile service URL or '
+                            'xyzservices.TileProvider not a {} type.'.format(type(self).__name__, type(data).__name__) )
         super().__init__(data, kdims=kdims, vdims=vdims, **params)
 
     def __call__(self, *args, **kwargs):

--- a/geoviews/element/geo.py
+++ b/geoviews/element/geo.py
@@ -241,8 +241,10 @@ class WMTS(_GeoFeature):
         elif WebMapTileService and isinstance(data, WebMapTileService):
             pass
         elif data is not None and not isinstance(data, (str, dict)):
-            raise TypeError('{} data should be a tile service URL or '
-                            'xyzservices.TileProvider not a {} type.'.format(type(self).__name__, type(data).__name__) )
+            raise TypeError(
+                f'{type(self).__name__} data should be a tile service URL or '
+                f'xyzservices.TileProvider not a {type(data).__name__} type.'
+            )
         super().__init__(data, kdims=kdims, vdims=vdims, **params)
 
     def __call__(self, *args, **kwargs):

--- a/geoviews/tests/plotting/bokeh/test_tiles.py
+++ b/geoviews/tests/plotting/bokeh/test_tiles.py
@@ -1,0 +1,19 @@
+
+import pytest
+
+from geoviews.element import WMTS
+
+from holoviews.tests.plotting.bokeh.test_plot import TestBokehPlot, bokeh_renderer
+
+class TestWMTSPlot(TestBokehPlot):
+
+    def test_xyzservices_tileprovider(self):
+        xyzservices = pytest.importorskip("xyzservices")
+        osm = xyzservices.providers.OpenStreetMap.Mapnik
+
+        tiles = WMTS(osm)
+        plot = bokeh_renderer.get_plot(tiles)
+        glyph = plot.handles["glyph"]
+        assert glyph.attribution == osm.html_attribution
+        assert glyph.url == osm.build_url(scale_factor="@2x")
+        assert glyph.max_zoom == osm.max_zoom

--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,7 @@ _required = [
     'param',
     'panel >=1.0.0',
     'pyproj',
+    'xyzservices',
 ]
 
 _recommended = [


### PR DESCRIPTION
Closes https://github.com/holoviz/geoviews/issues/517 and finishes https://github.com/holoviz/holoviews/issues/5057

Based off https://github.com/holoviz/holoviews/pull/5062/files

```python
import geoviews as gv
import xyzservices.providers as xyz
gv.extension("bokeh")

gv.WMTS(xyz.NASAGIBS.ViirsEarthAtNight2012)
```
<img width="484" alt="image" src="https://github.com/holoviz/geoviews/assets/15331990/3ebb40e3-61bc-4bb1-9463-ff079eb5692d">
