### PR TITLE
Fix version check for warnings

### DIFF
--- a/geoviews/_warnings.py
+++ b/geoviews/_warnings.py
@@ -42,9 +42,7 @@ def find_stack_level():
     while frame:
         fname = inspect.getfile(frame)
         if (
-            fname.startswith(pkg_dir)
-            or fname.startswith(param_dir)
-            or fname.startswith(hv_dir)
+            fname.startswith((pkg_dir, param_dir, hv_dir))
         ) and not fname.startswith(test_dir):
             frame = frame.f_back
             stacklevel += 1
@@ -62,7 +60,7 @@ def deprecated(remove_version, old, new=None, extra=None):
     if isinstance(remove_version, str):
         remove_version = Version(remove_version)
 
-    if remove_version < current_version:
+    if remove_version <= current_version:
         # This error is mainly for developers to remove the deprecated.
         raise ValueError(
             f"{old!r} should have been removed in {remove_version}"


### PR DESCRIPTION
Small bug where we did not check if the remove version was equal to the current version. 

Also, combined all the `startswith` into one. 