### PR TITLE
Remove deprecated np.product

### DIFF
--- a/geoviews/data/iris.py
+++ b/geoviews/data/iris.py
@@ -352,7 +352,7 @@ class CubeInterface(GridInterface):
         """
         Returns the total number of samples in the dataset.
         """
-        return np.product([len(d.points) for d in dataset.data.coords(dim_coords=True)], dtype=np.intp)
+        return np.prod([len(d.points) for d in dataset.data.coords(dim_coords=True)], dtype=np.intp)
 
 
     @classmethod


### PR DESCRIPTION
Removes warning seen in numpy 1.25:

```
❯ python -Wdefault -c "import numpy as np; np.product([1])"
sys:1: DeprecationWarning: `product` is deprecated as of NumPy 1.25.0, and will be removed in NumPy 2.0. Please use `prod` instead.
``` 