### PR TITLE
Update to Bokeh 3.2 and update CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -56,6 +56,7 @@ jobs:
           conda install -c pyviz "pyctdev>=0.5"
           doit ecosystem_setup
           conda install -c conda-forge "urllib3<2.0.0" "conda-build==3.24"
+          conda install -n test-environment conda-libmamba-solver
       - name: conda build
         run: |
           doit package_build --recipe=core $CHANS_DEV $PKG_TEST_PYTHON --test-group=simple

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -56,7 +56,6 @@ jobs:
           conda install -c pyviz "pyctdev>=0.5"
           doit ecosystem_setup
           conda install -c conda-forge "urllib3<2.0.0" "conda-build==3.24"
-          conda install -n test-environment conda-libmamba-solver
       - name: conda build
         run: |
           doit package_build --recipe=core $CHANS_DEV $PKG_TEST_PYTHON --test-group=simple
@@ -82,6 +81,7 @@ jobs:
       - name: build js
         run: |
           eval "$(conda shell.bash hook)"
+          conda install -n test-environment conda-libmamba-solver
           conda activate test-environment
           doit develop_install $CHANS_DEV -o build
           python setup.py develop

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,6 +50,8 @@ jobs:
       - name: conda setup
         run: |
           conda config --set always_yes True
+          conda install -n base conda-libmamba-solver
+          conda config --set solver libmamba
           conda install -c pyviz "pyctdev>=0.5"
           doit ecosystem_setup
           conda install -c conda-forge "urllib3<2.0.0" "conda-build==3.24"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,6 +51,7 @@ jobs:
         run: |
           conda config --set always_yes True
           conda install -n base conda-libmamba-solver
+          conda install -n test conda-libmamba-solver
           conda config --set solver libmamba
           conda install -c pyviz "pyctdev>=0.5"
           doit ecosystem_setup

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,7 +59,6 @@ jobs:
           envs: "-o tests -o examples_extra -o recommended"
           cache: true
           conda-update: true
-          conda-mamba: mamba
           nodejs: true
         id: install
       - name: doit env_capture

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -61,10 +61,6 @@ jobs:
           conda-update: true
           nodejs: true
         id: install
-      - name: doit env_capture
-        run: |
-          conda activate test-environment
-          doit env_capture
       - name: download data
         run: |
           conda activate test-environment

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,7 +60,6 @@ jobs:
           cache: true
           conda-update: true
           nodejs: true
-          nodejs-version: 18
         id: install
       - name: download data
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,6 +60,7 @@ jobs:
           cache: true
           conda-update: true
           nodejs: true
+          nodejs-version: 18
         id: install
       - name: download data
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,7 +50,7 @@ jobs:
       SETUPTOOLS_ENABLE_FEATURES: "legacy-editable"
       USE_PYGEOS: '0'
     steps:
-      - uses: holoviz-dev/holoviz_tasks/install@v0.1a14
+      - uses: holoviz-dev/holoviz_tasks/install@v0.1a15
         with:
           name: unit_test_suite
           python-version: ${{ matrix.python-version }}

--- a/geoviews/models/poly_edit.ts
+++ b/geoviews/models/poly_edit.ts
@@ -31,7 +31,7 @@ export class PolyVertexEditToolView extends PolyEditToolView {
     if (this._basepoint == null || this.model.vertex_renderer == null)
       return
     const points = this._drag_points(ev, [this.model.vertex_renderer])
-    if (!ev.shift_key) {
+    if (!ev.modifiers.shift) {
       this._move_linked(points)
     }
     if (this._selected_renderer)
@@ -42,7 +42,7 @@ export class PolyVertexEditToolView extends PolyEditToolView {
     if (this._basepoint == null || this.model.vertex_renderer == null)
       return
     const points = this._drag_points(ev, [this.model.vertex_renderer])
-    if (!ev.shift_key) {
+    if (!ev.modifiers.shift) {
       this._move_linked(points)
     }
     this._emit_cds_changes(this.model.vertex_renderer.data_source, false, true, true)

--- a/geoviews/package-lock.json
+++ b/geoviews/package-lock.json
@@ -9,14 +9,14 @@
       "version": "1.10.1-a1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@bokeh/bokehjs": "~3.2"
+        "@bokeh/bokehjs": "~3.2.1"
       },
       "devDependencies": {}
     },
     "node_modules/@bokeh/bokehjs": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@bokeh/bokehjs/-/bokehjs-3.2.0.tgz",
-      "integrity": "sha512-YxKpc9IRux99S+SW1vqHA+H8X5nFwPWKQ/xlI14dJPHtnsQKkzPG1qXpWhjN/WBOu/H8urWPfIqBow976F3h0g==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@bokeh/bokehjs/-/bokehjs-3.2.1.tgz",
+      "integrity": "sha512-qtgWZ18ZfEyuRdOV3d3ZwtBmSZRdPmyBYpJl84VLqljNx3sQn6aeTuE5EZIkkDhB9YF74meU6fmHwt/+WpsFuQ==",
       "engines": {
         "node": ">=16.0",
         "npm": ">=8.0"
@@ -25,9 +25,9 @@
   },
   "dependencies": {
     "@bokeh/bokehjs": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@bokeh/bokehjs/-/bokehjs-3.2.0.tgz",
-      "integrity": "sha512-YxKpc9IRux99S+SW1vqHA+H8X5nFwPWKQ/xlI14dJPHtnsQKkzPG1qXpWhjN/WBOu/H8urWPfIqBow976F3h0g=="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@bokeh/bokehjs/-/bokehjs-3.2.1.tgz",
+      "integrity": "sha512-qtgWZ18ZfEyuRdOV3d3ZwtBmSZRdPmyBYpJl84VLqljNx3sQn6aeTuE5EZIkkDhB9YF74meU6fmHwt/+WpsFuQ=="
     }
   }
 }

--- a/geoviews/package-lock.json
+++ b/geoviews/package-lock.json
@@ -9,14 +9,14 @@
       "version": "1.10.1-a1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@bokeh/bokehjs": "~3.1.1"
+        "@bokeh/bokehjs": "~3.2"
       },
       "devDependencies": {}
     },
     "node_modules/@bokeh/bokehjs": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@bokeh/bokehjs/-/bokehjs-3.1.1.tgz",
-      "integrity": "sha512-+S3hqhIaOS17Xp0Oy7fB+hhOPe+v3jeIew40sWaH4/DEEMuUmhDZZMFowWhicuwTN9J6Bay9bp/62YJc5Na1Qg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@bokeh/bokehjs/-/bokehjs-3.2.0.tgz",
+      "integrity": "sha512-YxKpc9IRux99S+SW1vqHA+H8X5nFwPWKQ/xlI14dJPHtnsQKkzPG1qXpWhjN/WBOu/H8urWPfIqBow976F3h0g==",
       "engines": {
         "node": ">=16.0",
         "npm": ">=8.0"
@@ -25,9 +25,9 @@
   },
   "dependencies": {
     "@bokeh/bokehjs": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@bokeh/bokehjs/-/bokehjs-3.1.1.tgz",
-      "integrity": "sha512-+S3hqhIaOS17Xp0Oy7fB+hhOPe+v3jeIew40sWaH4/DEEMuUmhDZZMFowWhicuwTN9J6Bay9bp/62YJc5Na1Qg=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@bokeh/bokehjs/-/bokehjs-3.2.0.tgz",
+      "integrity": "sha512-YxKpc9IRux99S+SW1vqHA+H8X5nFwPWKQ/xlI14dJPHtnsQKkzPG1qXpWhjN/WBOu/H8urWPfIqBow976F3h0g=="
     }
   }
 }

--- a/geoviews/package.json
+++ b/geoviews/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/holoviz/geoviews.git"
   },
   "dependencies": {
-    "@bokeh/bokehjs": "~3.2"
+    "@bokeh/bokehjs": "~3.2.1"
   },
   "devDependencies": {},
   "files": [

--- a/geoviews/package.json
+++ b/geoviews/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/holoviz/geoviews.git"
   },
   "dependencies": {
-    "@bokeh/bokehjs": "~3.1.1"
+    "@bokeh/bokehjs": "~3.2"
   },
   "devDependencies": {},
   "files": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "param >=1.9.0",
     "pyct >=0.4.4",
-    "bokeh >=3.1.0,<3.2.0",
+    "bokeh >=3.1.0,<3.3.0",
     "pyviz_comms >=0.6.0",
     "setuptools",
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,4 @@ license_files = LICENSE
 [tool:pyctdev.conda]
 namespace_map =
     geopandas=geopandas-base
+    matplotlib=matplotlib-base

--- a/setup.py
+++ b/setup.py
@@ -165,7 +165,6 @@ extras_require['build'] = [
     'pyct >=0.4.4',
     'bokeh >=3.1.0,<3.3.0',
     'pyviz_comms >=0.6.0',
-    'conda-libmamba-solver', # Needed as we create a new environment with a conda in it
 ]
 
 ########################

--- a/setup.py
+++ b/setup.py
@@ -122,6 +122,7 @@ _recommended = [
 
 # can only currently run all examples with packages from conda-forge
 _examples_extra = _recommended + [
+    'iris >=3.5',  # Pin to support numpy 1.24
     'xesmf',
     'mock',
     'fiona',
@@ -129,8 +130,8 @@ _examples_extra = _recommended + [
 ]
 
 if sys.version_info[:2] == (3, 8):
-    _examples_extra += [
-        'iris >=3.5',  # Pin to support numpy 1.24
+    _recommended += [
+        "pillow <10"
     ]
 
 extras_require={

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,6 @@ _recommended = [
     # geopandas-base installed with conda, see setup.cfg
     'geopandas',
     'netcdf4',
-    'jupyter',
     'matplotlib >3.3',
     'pandas',
     'pyct',

--- a/setup.py
+++ b/setup.py
@@ -122,12 +122,16 @@ _recommended = [
 
 # can only currently run all examples with packages from conda-forge
 _examples_extra = _recommended + [
-    'iris >=3.5',  # Pin to support numpy 1.24
     'xesmf',
     'mock',
     'fiona',
     'geodatasets',
 ]
+
+if sys.version_info[:2] == (3, 8):
+    _examples_extra += [
+        'iris >=3.5',  # Pin to support numpy 1.24
+    ]
 
 extras_require={
     'recommended': _recommended,

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ except:
 ### dependencies ###
 
 _required = [
-    'bokeh >=3.1.0,<3.2.0',
+    'bokeh >=3.1.0,<3.3.0',
     'cartopy >=0.18.0',
     'holoviews >=1.16.0',
     'packaging',
@@ -159,7 +159,7 @@ extras_require['all'] = sorted(set(sum(extras_require.values(), [])))
 extras_require['build'] = [
     'param >=1.9.2',
     'pyct >=0.4.4',
-    'bokeh >=3.1.0,<3.2.0',
+    'bokeh >=3.1.0,<3.3.0',
     'pyviz_comms >=0.6.0'
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ _recommended = [
     'geopandas',
     'netcdf4',
     'jupyter',
-    'matplotlib >2.2',
+    'matplotlib >3.3',
     'pandas',
     'pyct',
     'scipy',

--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,7 @@ _examples_extra = _recommended + [
 
 if sys.version_info[:2] == (3, 8):
     _recommended += [
-        "pillow <10"
+        "iris ==3.5"  # Hard pin for Windows + Python 3.8
     ]
 
 extras_require={

--- a/setup.py
+++ b/setup.py
@@ -164,7 +164,8 @@ extras_require['build'] = [
     'param >=1.9.2',
     'pyct >=0.4.4',
     'bokeh >=3.1.0,<3.3.0',
-    'pyviz_comms >=0.6.0'
+    'pyviz_comms >=0.6.0',
+    'conda-libmamba-solver', # Needed as we create a new environment with a conda in it
 ]
 
 ########################

--- a/setup.py
+++ b/setup.py
@@ -138,7 +138,7 @@ extras_require={
     'recommended': _recommended,
     'examples_extra': _examples_extra,
     'doc': _examples_extra + [
-        'nbsite ==0.8.0',
+        'nbsite >=0.8.2,<0.9.0',
         'cartopy >=0.20.0',
         'graphviz',
         'lxml',

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ _recommended = [
     # geopandas-base installed with conda, see setup.cfg
     'geopandas',
     'netcdf4',
-    'matplotlib >3.3',
+    'matplotlib >2.2',
     'pandas',
     'pyct',
     'scipy',
@@ -130,7 +130,7 @@ _examples_extra = _recommended + [
 ]
 
 if sys.version_info[:2] == (3, 8):
-    _recommended += [
+    _examples_extra += [
         "iris ==3.5"  # Hard pin for Windows + Python 3.8
     ]
 


### PR DESCRIPTION
I will wait with this merge until Bokeh 3.2.1 is released and use that for the Bokeh models. 

I'm also using this PR to get the CI up and running again for tests, docs, and builds.

Added the libmamba solver to the package build, and the time went from 1 hour and 11 minutes down to 18 minutes. 