### PR TITLE
Remove calling `.cols(3)` on the homepage

### DIFF
--- a/examples/Homepage.ipynb
+++ b/examples/Homepage.ipynb
@@ -31,7 +31,7 @@
    "outputs": [],
    "source": [
     "(gf.ocean + gf.land + gf.ocean * gf.land * gf.coastline * gf.borders).opts(\n",
-    "    'Feature', projection=crs.Geostationary(), global_extent=True, height=325).cols(3)"
+    "    'Feature', projection=crs.Geostationary(), global_extent=True, height=325)"
    ]
   },
   {


### PR DESCRIPTION
I noticed this somewhat strange call to `.cols(3)` on the first example. Running that in a notebook, I saw no difference. Happy to hear if there's one! If not I suggest removing it.

![image](https://github.com/holoviz/geoviews/assets/35924738/9e034040-2a5a-4e8e-b184-6229c33d6b0b)
