### PR TITLE
Change default zoom_level on Matplotlib's WMTS 

### DIFF
--- a/geoviews/plotting/mpl/__init__.py
+++ b/geoviews/plotting/mpl/__init__.py
@@ -487,7 +487,7 @@ class WMTSPlot(GeoPlot):
     Adds a Web Map Tile Service from a WMTS Element.
     """
 
-    zoom = param.Integer(default=8, doc="""
+    zoom = param.Integer(default=3, doc="""
         Controls the zoom level of the tile source.""")
 
     style_opts = ['alpha', 'cmap', 'interpolation', 'visible',

--- a/geoviews/util.py
+++ b/geoviews/util.py
@@ -745,8 +745,6 @@ def from_xarray(da, crs=None, apply_transform=False, nan_nodata=False, **kwargs)
         from .element.geo import RGB, HvRGB
         el = RGB if 'crs' in kwargs else HvRGB
         vdims = el.vdims[:bands]
-        if bands == 4:
-            vdims.append("A")
         el = el(data, [x, y], vdims, **kwargs)
     if hasattr(el.data, 'attrs'):
         el.data.attrs = da.attrs

--- a/geoviews/util.py
+++ b/geoviews/util.py
@@ -745,6 +745,8 @@ def from_xarray(da, crs=None, apply_transform=False, nan_nodata=False, **kwargs)
         from .element.geo import RGB, HvRGB
         el = RGB if 'crs' in kwargs else HvRGB
         vdims = el.vdims[:bands]
+        if bands == 4:
+            vdims.append("A")
         el = el(data, [x, y], vdims, **kwargs)
     if hasattr(el.data, 'attrs'):
         el.data.attrs = da.attrs


### PR DESCRIPTION
If users ran `gvts.OSM()` on a global extent with the original zoom=8, it'll fetch many many tiles, and probably gets the user rate limited.

I tried to use the `utils.zoom_level` to auto determine zoom, but I couldn't find a way to extract the bounds from WMTS.


```python
import geoviews as gv
from geoviews import opts, tile_sources as gvts

gv.extension('matplotlib')

gvts.OSM()
```

<img width="712" alt="image" src="https://github.com/holoviz/geoviews/assets/15331990/14568333-ca61-40b7-8082-242cf3d9e665">
