### PR TITLE
Align build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,8 @@
 [build-system]
 requires = [
-    "param >=1.9.0",
+    "param >=1.9.2",
     "pyct >=0.4.4",
     "bokeh ==3.3",
-    "pyviz_comms >=0.6.0",
     "setuptools",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -150,6 +150,7 @@ extras_require={
         'shapely',
         'xarray',
         'pooch',
+        'pyviz_comms',
     ],
     'tests': [
         'nbval',
@@ -172,7 +173,7 @@ extras_require['build'] = [
     'param >=1.9.2',
     'pyct >=0.4.4',
     'bokeh ==3.3',
-    'pyviz_comms >=0.6.0',
+    'setuptools',
 ]
 
 ########################


### PR DESCRIPTION
- Remove `pyviz_comms` from the build dependencies (see https://discord.com/channels/1075331058024861767/1101491338899370014/1212395663099433051)
- Add `pyviz_comms` to the test dependencies as a unit test requires it
- Align build deps in setup.py and pyproject.toml