### PR TITLE
Doc: build the site without pulling the dev dependencies

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -40,7 +40,7 @@ jobs:
           name: Documentation
           python-version: "3.10"
           channel-priority: strict
-          channels: conda-forge,nodefaults
+          channels: pyviz,conda-forge,nodefaults
           envs: "-o doc -o examples_extra"
           cache: true
           conda-update: true

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -35,34 +35,18 @@ jobs:
       MOZ_HEADLESS: 1
       DISPLAY: ":99.0"
     steps:
-      - uses: actions/checkout@v3
+      - uses: holoviz-dev/holoviz_tasks/install@v0.1a19
         with:
-          fetch-depth: "100"
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          miniconda-version: "latest"
-      - name: Fetch unshallow
-        run: git fetch --prune --tags --unshallow -f
+          name: Documentation
+          python-version: "3.10"
+          channel-priority: strict
+          channels: conda-forge,nodefaults
+          envs: "-o doc -o examples_extra"
+          cache: true
+          conda-update: true
       - name: Set output
         id: vars
         run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
-      - name: conda setup
-        run: |
-          conda create -n test-environment
-          conda activate test-environment
-          conda config --env --append channels pyviz/label/dev --append channels bokeh --append channels conda-forge
-          conda config --env --remove channels defaults
-          conda config --env --set channel_priority strict
-          conda config --env --show-sources
-          conda install python=3.9 pyctdev
-      - name: doit develop_install
-        run: |
-          conda activate test-environment
-          doit develop_install -o doc -o examples_extra
-      - name: doit env_capture
-        run: |
-          conda activate test-environment
-          doit env_capture
       - name: download data
         run: |
           conda activate test-environment

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -39,7 +39,6 @@ jobs:
         with:
           name: Documentation
           python-version: "3.10"
-          channel-priority: strict
           channels: pyviz,conda-forge,nodefaults
           envs: "-o doc -o examples_extra"
           cache: true


### PR DESCRIPTION
I think the latest release of GeoViews partially broke the website, by pulling the latest dev version of Panel but not the latest version of Bokeh. As a consequence, Bokeh plots aren't displayed.

![image](https://github.com/holoviz/geoviews/assets/35924738/f05a1304-0796-4513-9136-729dd21ac630)
![image](https://github.com/holoviz/geoviews/assets/35924738/fbe263d7-ddcc-49a9-ae3d-b42e775a7789)

This PR builds the site using the generic install action and only using `conda-forge`. I think generally we don't want to pull pre-releases when building the websites. We sometimes need to add `pyviz/label/dev` to get the latest version of `nbsite`. By the way, I may need to either make a final release of nbsite or pull its latest dev version for doc build to succeed here, I'll see after manually running it for Github's UI.