### PR TITLE
NO MERGE - Temp. allow dev channels for build step

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -120,7 +120,7 @@ jobs:
           name: pip
           path: dist/
       - name: Install package
-        run: python -m pip install dist/*.whl --pre
+        run: python -m pip install dist/*.whl
       - name: Test package
         run: python -c "import $PACKAGE; print($PACKAGE.__version__)"
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -120,7 +120,7 @@ jobs:
           name: pip
           path: dist/
       - name: Install package
-        run: python -m pip install dist/*.whl
+        run: python -m pip install dist/*.whl --pre
       - name: Test package
         run: python -c "import $PACKAGE; print($PACKAGE.__version__)"
 

--- a/scripts/conda/build.sh
+++ b/scripts/conda/build.sh
@@ -19,8 +19,8 @@ else:
     print('bokeh')
 ")
 
-conda build scripts/conda/recipe-core --no-anaconda-upload --no-verify -c "$BK_CHANNEL" -c pyviz/label/dev
-conda build scripts/conda/recipe-recommended --no-anaconda-upload --no-verify  -c "$BK_CHANNEL" -c pyviz/label/dev
+conda build scripts/conda/recipe-core --no-anaconda-upload --no-verify -c "$BK_CHANNEL" -c pyviz
+conda build scripts/conda/recipe-recommended --no-anaconda-upload --no-verify  -c "$BK_CHANNEL" -c pyviz
 
 mv "$CONDA_PREFIX/conda-bld/noarch/$PACKAGE-core-$VERSION-py_0.tar.bz2" dist
 mv "$CONDA_PREFIX/conda-bld/noarch/$PACKAGE-$VERSION-py_0.tar.bz2" dist

--- a/scripts/conda/build.sh
+++ b/scripts/conda/build.sh
@@ -19,8 +19,8 @@ else:
     print('bokeh')
 ")
 
-conda build scripts/conda/recipe-core --no-anaconda-upload --no-verify -c "$BK_CHANNEL"
-conda build scripts/conda/recipe-recommended --no-anaconda-upload --no-verify  -c "$BK_CHANNEL"
+conda build scripts/conda/recipe-core --no-anaconda-upload --no-verify -c "$BK_CHANNEL" -c pyviz/label/dev
+conda build scripts/conda/recipe-recommended --no-anaconda-upload --no-verify  -c "$BK_CHANNEL" -c pyviz/label/dev
 
 mv "$CONDA_PREFIX/conda-bld/noarch/$PACKAGE-core-$VERSION-py_0.tar.bz2" dist
 mv "$CONDA_PREFIX/conda-bld/noarch/$PACKAGE-$VERSION-py_0.tar.bz2" dist


### PR DESCRIPTION
The last build did not succeed because it could not install a Panel + Bokeh 3.5 compatible version. This adds the needed changes to make it work.
 
https://github.com/holoviz/geoviews/actions/runs/10203532098
![image](https://github.com/user-attachments/assets/e2557444-cccc-4350-b739-91c80b2d4f71)

