### PR TITLE
compat: Dask 2024.11

### DIFF
--- a/geoviews/tests/conftest.py
+++ b/geoviews/tests/conftest.py
@@ -1,7 +1,5 @@
 from contextlib import suppress
 
-from holoviews.tests.conftest import bokeh_backend, port, serve_hv  # noqa: F401
-
 import geoviews as gv
 
 CUSTOM_MARKS = ("ui",)

--- a/geoviews/tests/conftest.py
+++ b/geoviews/tests/conftest.py
@@ -50,10 +50,3 @@ with suppress(ImportError):
     import matplotlib.pyplot as plt
 
     plt.switch_backend("agg")
-
-with suppress(Exception):
-    # From Dask 2024.3.0 they now use `dask_expr` by default
-    # https://github.com/dask/dask/issues/10995
-    import dask
-
-    dask.config.set({"dataframe.query-planning": False})

--- a/geoviews/tests/conftest.py
+++ b/geoviews/tests/conftest.py
@@ -1,6 +1,44 @@
 from contextlib import suppress
 
+from holoviews.tests.conftest import bokeh_backend, port, serve_hv  # noqa: F401
+
 import geoviews as gv
+
+CUSTOM_MARKS = ("ui",)
+
+
+def pytest_addoption(parser):
+    for marker in CUSTOM_MARKS:
+        parser.addoption(
+            f"--{marker}",
+            action="store_true",
+            default=False,
+            help=f"Run {marker} related tests",
+        )
+
+
+def pytest_configure(config):
+    for marker in CUSTOM_MARKS:
+        config.addinivalue_line("markers", f"{marker}: {marker} test marker")
+
+
+def pytest_collection_modifyitems(config, items):
+    skipped, selected = [], []
+    markers = [m for m in CUSTOM_MARKS if config.getoption(f"--{m}")]
+    empty = not markers
+    for item in items:
+        if empty and any(m in item.keywords for m in CUSTOM_MARKS):
+            skipped.append(item)
+        elif empty:
+            selected.append(item)
+        elif not empty and any(m in item.keywords for m in markers):
+            selected.append(item)
+        else:
+            skipped.append(item)
+
+    config.hook.pytest_deselected(items=skipped)
+    items[:] = selected
+
 
 with suppress(Exception):
     gv.extension("bokeh")
@@ -14,11 +52,8 @@ with suppress(ImportError):
     plt.switch_backend("agg")
 
 with suppress(Exception):
-    # From Dask 2023.7.1 they now automatically convert strings
-    # https://docs.dask.org/en/stable/changelog.html#v2023-7-1
     # From Dask 2024.3.0 they now use `dask_expr` by default
     # https://github.com/dask/dask/issues/10995
     import dask
 
-    dask.config.set({"dataframe.convert-string": False})
     dask.config.set({"dataframe.query-planning": False})

--- a/geoviews/tests/conftest.py
+++ b/geoviews/tests/conftest.py
@@ -14,8 +14,11 @@ with suppress(ImportError):
     plt.switch_backend("agg")
 
 with suppress(Exception):
+    # From Dask 2023.7.1 they now automatically convert strings
+    # https://docs.dask.org/en/stable/changelog.html#v2023-7-1
     # From Dask 2024.3.0 they now use `dask_expr` by default
     # https://github.com/dask/dask/issues/10995
     import dask
 
+    dask.config.set({"dataframe.convert-string": False})
     dask.config.set({"dataframe.query-planning": False})

--- a/pixi.toml
+++ b/pixi.toml
@@ -10,7 +10,6 @@ sync-git-tags = 'python scripts/sync_git_tags.py geoviews'
 [activation.env]
 PYTHONIOENCODING = "utf-8"
 USE_PYGEOS = "0"
-DASK_DATAFRAME__QUERY_PLANNING = "False"
 
 [environments]
 test-310 = ["py310", "test-core", "test-unit-task", "test", "example", "test-example", "download-data"]
@@ -102,8 +101,6 @@ rioxarray = "*"
 scipy = "*"
 shapely = "*"
 xarray = "*"
-dask-core = "*"
-dask-expr = "*"
 
 [feature.test-example.tasks]
 test-example = 'pytest -n logical --dist loadscope --nbval-lax examples'

--- a/pixi.toml
+++ b/pixi.toml
@@ -101,6 +101,8 @@ rioxarray = "*"
 scipy = "*"
 shapely = "*"
 xarray = "*"
+dask-core = "*"
+dask-expr = "*"
 
 [feature.test-example.tasks]
 test-example = 'pytest -n logical --dist loadscope --nbval-lax examples'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,9 +175,9 @@ filterwarnings = [
     "ignore:\\s*Pyarrow will become a required dependency of pandas:DeprecationWarning", # Will go away by itself in Pandas 3.0
     "ignore:Passing a (SingleBlockManager|BlockManager) to (Series|GeoSeries|DataFrame|GeoDataFrame) is deprecated:DeprecationWarning", # https://github.com/holoviz/spatialpandas/issues/137
     "ignore:datetime.datetime.utcfromtimestamp():DeprecationWarning:dateutil.tz.tz", # https://github.com/dateutil/dateutil/pull/1285
-    # 2024-02
-    "ignore:The current Dask DataFrame implementation is deprecated:DeprecationWarning", # https://github.com/dask/dask/issues/10917
     # 2024-03
     "ignore:\\s*Dask dataframe query planning is disabled because dask-expr is not installed:FutureWarning",
     "ignore:numpy.ndarray size changed, may indicate binary incompatibility:RuntimeWarning", # https://github.com/pydata/xarray/issues/7259
+    # 2024-11
+    "ignore:The legacy Dask DataFrame implementation is deprecated and will be removed in a future version.:DeprecationWarning", # https://github.com/dask/dask/issues/10917
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,6 +178,4 @@ filterwarnings = [
     # 2024-03
     "ignore:\\s*Dask dataframe query planning is disabled because dask-expr is not installed:FutureWarning",
     "ignore:numpy.ndarray size changed, may indicate binary incompatibility:RuntimeWarning", # https://github.com/pydata/xarray/issues/7259
-    # 2024-11
-    "ignore:The legacy Dask DataFrame implementation is deprecated and will be removed in a future version.:FutureWarning", # https://github.com/dask/dask/issues/10917
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,5 +179,5 @@ filterwarnings = [
     "ignore:\\s*Dask dataframe query planning is disabled because dask-expr is not installed:FutureWarning",
     "ignore:numpy.ndarray size changed, may indicate binary incompatibility:RuntimeWarning", # https://github.com/pydata/xarray/issues/7259
     # 2024-11
-    "ignore:The legacy Dask DataFrame implementation is deprecated and will be removed in a future version.:DeprecationWarning", # https://github.com/dask/dask/issues/10917
+    "ignore:The legacy Dask DataFrame implementation is deprecated and will be removed in a future version.:FutureWarning", # https://github.com/dask/dask/issues/10917
 ]


### PR DESCRIPTION
Hopefully?

> ERROR geoviews/tests/test_projection.py - FutureWarning: The legacy Dask DataFrame implementation is deprecated and will be removed in a future version. Set the configuration option `dataframe.query-planning` to `True` or None to enable the new Dask Dataframe implementation and silence this warning.

Taken from https://github.com/holoviz/holoviews/pull/6149/files