### PR TITLE
build: Small updates to build infrastructure

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -126,7 +126,7 @@ jobs:
       - name: Install package
         run: python -m pip install dist/*.whl
       - name: Test package
-        run: python -c "import $PACKAGE; print($PACKAGE.__version__)"
+        run: python -c "import $PACKAGE; print($PACKAGE._version.__version__)"
 
   pip_publish:
     name: Publish PyPI

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -77,6 +77,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           miniconda-version: "latest"
+          channels: "conda-forge"
       - name: conda setup
         run: |
           conda install -y anaconda-client

--- a/geoviews/package-lock.json
+++ b/geoviews/package-lock.json
@@ -858,9 +858,10 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -2619,9 +2620,9 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "requires": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,12 +68,14 @@ raw-options = { version_scheme = "no-guess-dev" }
 
 [tool.hatch.build.targets.wheel]
 include = ["geoviews"]
+exclude = ["geoviews/node_modules"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "geoviews/dist" = "geoviews/dist"
 
 [tool.hatch.build.targets.sdist]
 include = ["geoviews", "scripts"]
+exclude = ["geoviews/node_modules"]
 
 [tool.hatch.build.targets.sdist.force-include]
 "geoviews/dist" = "geoviews/dist"

--- a/scripts/conda/build.sh
+++ b/scripts/conda/build.sh
@@ -19,7 +19,7 @@ else:
     print('bokeh')
 ")
 
-conda build scripts/conda/recipe-core --no-anaconda-upload --no-verify -c pyviz -c "$BK_CHANNEL"  -c conda-forge --package-format 1
+conda build scripts/conda/recipe-core --no-anaconda-upload --no-verify -c pyviz -c "$BK_CHANNEL" -c conda-forge --package-format 1
 conda build scripts/conda/recipe-recommended --no-anaconda-upload --no-verify -c pyviz -c "$BK_CHANNEL" -c conda-forge --package-format 1
 
 mv "$CONDA_PREFIX/conda-bld/noarch/$PACKAGE-core-$VERSION-py_0.tar.bz2" dist

--- a/scripts/conda/build.sh
+++ b/scripts/conda/build.sh
@@ -14,13 +14,13 @@ import bokeh
 from packaging.version import Version
 
 if Version(bokeh.__version__).is_prerelease:
-    print('bokeh/label/dev')
+    print('bokeh/label/rc')
 else:
     print('bokeh')
 ")
 
-conda build scripts/conda/recipe-core --no-anaconda-upload --no-verify -c conda-forge -c "$BK_CHANNEL" -c pyviz --package-format 1
-conda build scripts/conda/recipe-recommended --no-anaconda-upload --no-verify -c conda-forge -c "$BK_CHANNEL" -c pyviz --package-format 1
+conda build scripts/conda/recipe-core --no-anaconda-upload --no-verify -c pyviz -c "$BK_CHANNEL"  -c conda-forge --package-format 1
+conda build scripts/conda/recipe-recommended --no-anaconda-upload --no-verify -c pyviz -c "$BK_CHANNEL" -c conda-forge --package-format 1
 
 mv "$CONDA_PREFIX/conda-bld/noarch/$PACKAGE-core-$VERSION-py_0.tar.bz2" dist
 mv "$CONDA_PREFIX/conda-bld/noarch/$PACKAGE-$VERSION-py_0.tar.bz2" dist

--- a/scripts/conda/build.sh
+++ b/scripts/conda/build.sh
@@ -19,8 +19,8 @@ else:
     print('bokeh')
 ")
 
-conda build scripts/conda/recipe-core --no-anaconda-upload --no-verify -c "$BK_CHANNEL" -c pyviz
-conda build scripts/conda/recipe-recommended --no-anaconda-upload --no-verify  -c "$BK_CHANNEL" -c pyviz
+conda build scripts/conda/recipe-core --no-anaconda-upload --no-verify -c conda-forge -c "$BK_CHANNEL" -c pyviz --package-format 1
+conda build scripts/conda/recipe-recommended --no-anaconda-upload --no-verify -c conda-forge -c "$BK_CHANNEL" -c pyviz --package-format 1
 
 mv "$CONDA_PREFIX/conda-bld/noarch/$PACKAGE-core-$VERSION-py_0.tar.bz2" dist
 mv "$CONDA_PREFIX/conda-bld/noarch/$PACKAGE-$VERSION-py_0.tar.bz2" dist

--- a/scripts/conda/build.sh
+++ b/scripts/conda/build.sh
@@ -4,7 +4,7 @@ set -euxo pipefail
 
 PACKAGE="geoviews"
 
-python -m build . # Can add -w when this is solved: https://github.com/pypa/hatch/issues/1305
+python -m build --sdist .
 
 VERSION=$(python -c "import $PACKAGE; print($PACKAGE._version.__version__)")
 export VERSION

--- a/scripts/conda/recipe-core/meta.yaml
+++ b/scripts/conda/recipe-core/meta.yaml
@@ -6,11 +6,11 @@ package:
   version: {{ VERSION }}
 
 source:
-  url: ../../../dist/{{ project["name"] }}-{{ VERSION }}-py3-none-any.whl
+  url: ../../../dist/{{ project["name"] }}-{{ VERSION }}.tar.gz
 
 build:
   noarch: python
-  script: {{ PYTHON }} -m pip install --no-deps -vv {{ project["name"] }}-{{ VERSION }}-py3-none-any.whl
+  script: {{ PYTHON }} -m pip install --no-deps -vv .
   entry_points:
     {% for group,epoints in project.get("entry_points",{}).items() %}
     {% for entry_point in epoints %}

--- a/scripts/conda/recipe-recommended/meta.yaml
+++ b/scripts/conda/recipe-recommended/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ VERSION }}
 
 source:
-  url: ../../../dist/{{ project["name"] }}-{{ VERSION }}-py3-none-any.whl
+  url: ../../../dist/{{ project["name"] }}-{{ VERSION }}.tar.gz
 
 build:
   noarch: python


### PR DESCRIPTION
- Apply changes to exclude node_modules. See https://github.com/holoviz/panel/pull/7526. It does not seem to have affected GeoViews 1.13.1rc0. But it cannot hurt!
- Moving the conda-build step to use sdist instead of the wheel as was done in: https://github.com/holoviz/param/pull/97, and what is done on conda-forge
- Add the newly introduced `--package-format` to the conda-build command to ensure that the correct package format is always used. No change to the format itself! See https://github.com/conda/conda-build/releases/tag/24.11.0
- Remove the warning emitted from the publish step in:
![image](https://github.com/user-attachments/assets/0f16ef68-3089-4000-ad00-704a8dc33f98)
- Run `npm audit fix`
- Use `$PACKAGE._version.__version__` to be sure the _version.py file has been created.
- Use `bokeh/label/rc` for the conda build workflow. 


The difference in build between this PR and the GeoViews 1.13.1rc0 is:


``` yaml
Geoviews - wheel has identical filelist
Geoviews - sdist has identical filelist
                           Geoviews - conda #1
┏━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Files only in run 1     ┃ Files only in run 2                         ┃
┃ geoviews core 1.13.1rc0 ┃ geoviews core 1.13.1rc0.post1.dev4+g735ab14 ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ -                       │ site-packages/geoviews/.bokeh               │
└─────────────────────────┴─────────────────────────────────────────────┘
Geoviews - npmjs has identical filelist
```