### PR TITLE
Convert docstrings to Numpydoc style

### DIFF
--- a/geoviews/_warnings.py
+++ b/geoviews/_warnings.py
@@ -23,8 +23,7 @@ def warn(message, category=None, stacklevel=None):
 
 
 def find_stack_level():
-    """
-    Find the first place in the stack that is not inside
+    """Find the first place in the stack that is not inside
     Geoviews, Holoviews, or Param.
 
     Inspired by: pandas.util._exceptions.find_stack_level
@@ -79,12 +78,14 @@ def deprecated(remove_version, old, new=None, extra=None):
 
 class GeoviewsDeprecationWarning(DeprecationWarning):
     """A Geoviews-specific ``DeprecationWarning`` subclass.
+
     Used to selectively filter Geoviews deprecations for unconditional display.
     """
 
 
 class GeoviewsUserWarning(UserWarning):
     """A Geoviews-specific ``UserWarning`` subclass.
+
     Used to selectively filter Geoviews warnings for unconditional display.
     """
 

--- a/geoviews/annotators.py
+++ b/geoviews/annotators.py
@@ -51,9 +51,7 @@ PathAnnotator._vertex_table_link = get_vertex_table_link
 PolyAnnotator._vertex_table_link = get_vertex_table_link
 
 def initialize_tools(plot, element):
-    """
-    Initializes the Checkpoint and Restore tools.
-    """
+    """Initializes the Checkpoint and Restore tools."""
     cds = plot.handles['source']
     checkpoint = plot.state.select(type=CheckpointTool)
     restore = plot.state.select(type=RestoreTool)

--- a/geoviews/data/geopandas.py
+++ b/geoviews/data/geopandas.py
@@ -579,9 +579,9 @@ def to_geopandas(data, xdim, ydim, columns=None, geom='point'):
         apart from the geometry. Defaults to an empty list.
     geom : {'point', 'Line', 'Polygon'}, default='point'
         Specifies the geometry type to construct. Supports:
-        - 'point': Point or MultiPoint
+        - 'point' : Point or MultiPoint
         - 'Line' : LineString or MultiLineString
-        - 'Polygon': Polygon or MultiPolygon
+        - 'Polygon' : Polygon or MultiPolygon
 
     Returns
     -------

--- a/geoviews/data/geopandas.py
+++ b/geoviews/data/geopandas.py
@@ -564,22 +564,30 @@ def get_geom_type(geom):
 
 
 def to_geopandas(data, xdim, ydim, columns=None, geom='point'):
-    """Converts list of dictionary format geometries to spatialpandas line geometries.
+    """Converts a list of geometry dictionaries into a GeoPandas GeoDataFrame.
 
     Parameters
     ----------
-    data
+    data : list of dict
         List of dictionaries representing individual geometries
-    xdim
+    xdim : str
         Name of x-coordinates column
-    ydim
+    ydim : str
         Name of y-coordinates column
-    ring
-        Whether the data represents a closed ring
+    columns : list of str, optional
+        List of additional column names to include in the resulting GeoDataFrame,
+        apart from the geometry. Defaults to an empty list.
+    geom : {'point', 'Line', 'Polygon'}, default='point'
+        Specifies the geometry type to construct. Supports:
+        - 'point': Point or MultiPoint
+        - 'Line' : LineString or MultiLineString
+        - 'Polygon': Polygon or MultiPolygon
 
     Returns
     -------
-    A spatialpandas.GeoDataFrame version of the data
+    geopandas.GeoDataFrame
+        A GeoDataFrame containing the parsed geometries in a 'geometry' column
+        along with any specified attribute columns.
     """
     from geopandas import GeoDataFrame
     from shapely.geometry import (

--- a/geoviews/data/geopandas.py
+++ b/geoviews/data/geopandas.py
@@ -629,7 +629,6 @@ def from_multi(eltype, data, kdims, vdims):
     -------
     A GeoDataFrame containing the data in the list based format.
     """
-
     from geopandas import GeoDataFrame
 
     new_data = []

--- a/geoviews/data/geopandas.py
+++ b/geoviews/data/geopandas.py
@@ -534,10 +534,14 @@ class GeoPandasInterface(PandasAPI, MultiInterface):
 def get_geom_type(geom):
     """Returns the HoloViews geometry type.
 
-    Args:
-        geom: A shapely geometry
+    Parameters
+    ----------
+    geom
+        A shapely geometry
 
-    Returns:
+    Returns
+    -------
+    str
         A string representing type of the geometry.
     """
     from shapely.geometry import (
@@ -562,14 +566,20 @@ def get_geom_type(geom):
 def to_geopandas(data, xdim, ydim, columns=None, geom='point'):
     """Converts list of dictionary format geometries to spatialpandas line geometries.
 
-    Args:
-        data: List of dictionaries representing individual geometries
-        xdim: Name of x-coordinates column
-        ydim: Name of y-coordinates column
-        ring: Whether the data represents a closed ring
+    Parameters
+    ----------
+    data
+        List of dictionaries representing individual geometries
+    xdim
+        Name of x-coordinates column
+    ydim
+        Name of y-coordinates column
+    ring
+        Whether the data represents a closed ring
 
-    Returns:
-        A spatialpandas.GeoDataFrame version of the data
+    Returns
+    -------
+    A spatialpandas.GeoDataFrame version of the data
     """
     from geopandas import GeoDataFrame
     from shapely.geometry import (
@@ -604,14 +614,20 @@ def to_geopandas(data, xdim, ydim, columns=None, geom='point'):
 def from_multi(eltype, data, kdims, vdims):
     """Converts list formats into geopandas.GeoDataFrame.
 
-    Args:
-        eltype: Element type to convert
-        data: The original data
-        kdims: The declared key dimensions
-        vdims: The declared value dimensions
+    Parameters
+    ----------
+    eltype
+        Element type to convert
+    data
+        The original data
+    kdims
+        The declared key dimensions
+    vdims
+        The declared value dimensions
 
-    Returns:
-        A GeoDataFrame containing the data in the list based format.
+    Returns
+    -------
+    A GeoDataFrame containing the data in the list based format.
     """
 
     from geopandas import GeoDataFrame

--- a/geoviews/data/iris.py
+++ b/geoviews/data/iris.py
@@ -141,7 +141,7 @@ class CubeInterface(GridInterface):
 
     @classmethod
     def irregular(cls, dataset, dim):
-        "CubeInterface does not support irregular data"
+        """CubeInterface does not support irregular data"""
         return False
 
 

--- a/geoviews/data/iris.py
+++ b/geoviews/data/iris.py
@@ -26,9 +26,7 @@ def get_date_format(coord):
 
 
 def coord_to_dimension(coord):
-    """
-    Converts an iris coordinate to a HoloViews dimension.
-    """
+    """Converts an iris coordinate to a HoloViews dimension."""
     kwargs = {}
     if coord.units.is_time_reference():
         kwargs['value_format'] = get_date_format(coord)
@@ -38,8 +36,7 @@ def coord_to_dimension(coord):
 
 
 def sort_coords(coord):
-    """
-    Sorts a list of DimCoords trying to ensure that
+    """Sorts a list of DimCoords trying to ensure that
     dates and pressure levels appear first and the
     longitude and latitude appear last in the correct
     order.
@@ -52,8 +49,7 @@ def sort_coords(coord):
 
 
 class CubeInterface(GridInterface):
-    """
-    The CubeInterface provides allows HoloViews to interact with iris
+    """The CubeInterface provides allows HoloViews to interact with iris
     Cube data. When passing an iris Cube to a HoloViews Element the
     init method will infer the dimensions of the Cube from its
     coordinates. Currently the interface only provides the basic
@@ -222,9 +218,7 @@ class CubeInterface(GridInterface):
 
     @classmethod
     def values(cls, dataset, dim, expanded=True, flat=True, compute=True, keep_index=False):
-        """
-        Returns an array of the values along the supplied dimension.
-        """
+        """Returns an array of the values along the supplied dimension."""
         dim = dataset.get_dimension(dim, strict=True)
         if dim in dataset.vdims:
             coord_names = [c.name() for c in dataset.data.dim_coords]
@@ -260,8 +254,7 @@ class CubeInterface(GridInterface):
 
     @classmethod
     def groupby(cls, dataset, dims, container_type=HoloMap, group_type=None, **kwargs):
-        """
-        Groups the data by one or more dimensions returning a container
+        """Groups the data by one or more dimensions returning a container
         indexed by the grouped dimensions containing slices of the
         cube wrapped in the group_type. This makes it very easy to
         break up a high-dimensional dataset into smaller viewable chunks.
@@ -302,9 +295,7 @@ class CubeInterface(GridInterface):
 
     @classmethod
     def concat_dim(cls, datasets, dim, vdims):
-        """
-        Concatenates datasets along one dimension
-        """
+        """Concatenates datasets along one dimension."""
         import iris
         try:
             from iris.util import equalise_attributes
@@ -323,9 +314,7 @@ class CubeInterface(GridInterface):
 
     @classmethod
     def range(cls, dataset, dimension):
-        """
-        Computes the range along a particular dimension.
-        """
+        """Computes the range along a particular dimension."""
         dim = dataset.get_dimension(dimension, strict=True)
         values = dataset.dimension_values(dim.name, False)
         return (np.nanmin(values), np.nanmax(values))
@@ -333,9 +322,7 @@ class CubeInterface(GridInterface):
 
     @classmethod
     def redim(cls, dataset, dimensions):
-        """
-        Rename coords on the Cube.
-        """
+        """Rename coords on the Cube."""
         new_dataset = dataset.data.copy()
         for name, new_dim in dimensions.items():
             if name == new_dataset.name():
@@ -348,17 +335,13 @@ class CubeInterface(GridInterface):
 
     @classmethod
     def length(cls, dataset):
-        """
-        Returns the total number of samples in the dataset.
-        """
+        """Returns the total number of samples in the dataset."""
         return np.prod([len(d.points) for d in dataset.data.coords(dim_coords=True)], dtype=np.intp)
 
 
     @classmethod
     def sort(cls, columns, by=None, reverse=False):
-        """
-        Cubes are assumed to be sorted by default.
-        """
+        """Cubes are assumed to be sorted by default."""
         if by is None:
             by = []
         return columns
@@ -366,17 +349,13 @@ class CubeInterface(GridInterface):
 
     @classmethod
     def aggregate(cls, columns, kdims, function, **kwargs):
-        """
-        Aggregation currently not implemented.
-        """
+        """Aggregation currently not implemented."""
         raise NotImplementedError
 
 
     @classmethod
     def sample(cls, dataset, samples=None):
-        """
-        Sampling currently not implemented.
-        """
+        """Sampling currently not implemented."""
         if samples is None:
             samples = []
         raise NotImplementedError
@@ -384,8 +363,8 @@ class CubeInterface(GridInterface):
 
     @classmethod
     def add_dimension(cls, columns, dimension, dim_pos, values, vdim):
-        """
-        Adding value dimensions not currently supported by iris interface.
+        """Adding value dimensions not currently supported by iris interface.
+
         Adding key dimensions not possible on dense interfaces.
         """
         if not vdim:
@@ -395,9 +374,7 @@ class CubeInterface(GridInterface):
 
     @classmethod
     def select_to_constraint(cls, dataset, selection):
-        """
-        Transform a selection dictionary to an iris Constraint.
-        """
+        """Transform a selection dictionary to an iris Constraint."""
         import iris
 
         def get_slicer(start, end):
@@ -419,9 +396,7 @@ class CubeInterface(GridInterface):
 
     @classmethod
     def select(cls, dataset, selection_mask=None, **selection):
-        """
-        Apply a selection to the data.
-        """
+        """Apply a selection to the data."""
         import iris
         constraint = cls.select_to_constraint(dataset, selection)
         pre_dim_coords = [c.name() for c in dataset.data.dim_coords]

--- a/geoviews/element/__init__.py
+++ b/geoviews/element/__init__.py
@@ -69,8 +69,7 @@ __all__ = (
 
 
 class GeoConversion(ElementConversion):
-    """
-    GeoConversion is a very simple container object which can
+    """GeoConversion is a very simple container object which can
     be given an existing Dataset and provides methods to convert
     the Dataset into most other Element types. If the requested
     key dimensions correspond to geographical coordinates the

--- a/geoviews/element/comparison.py
+++ b/geoviews/element/comparison.py
@@ -20,9 +20,7 @@ class Comparison(HvComparison):
 
 
 class ComparisonTestCase(Comparison, TestCase):
-    """
-    Class to integrate the Comparison class with unittest.TestCase.
-    """
+    """Class to integrate the Comparison class with unittest.TestCase."""
 
     def __init__(self, *args, **kwargs):
         TestCase.__init__(self, *args, **kwargs)

--- a/geoviews/element/geo.py
+++ b/geoviews/element/geo.py
@@ -88,8 +88,7 @@ def _check_bokeh_mercator(data) -> bool:
     return False
 
 def is_geographic(element, kdims=None):
-    """
-    Utility to determine whether the supplied element optionally
+    """Utility to determine whether the supplied element optionally
     a subset of its key dimensions represent a geographic coordinate
     system.
     """
@@ -112,8 +111,7 @@ def is_geographic(element, kdims=None):
 
 
 class _Element(Element2D):
-    """
-    Baseclass for Element2D types with associated cartopy
+    """Baseclass for Element2D types with associated cartopy
     coordinate reference system.
     """
 
@@ -160,8 +158,7 @@ class _Element(Element2D):
 
 
 class _GeoFeature(_Element):
-    """
-    Baseclass for geographic types without their own data.
+    """Baseclass for geographic types without their own data.
     """
 
     _auxiliary_component = True
@@ -174,8 +171,7 @@ class _GeoFeature(_Element):
 
 
 class Feature(_GeoFeature):
-    """
-    A Feature represents a geographical feature
+    """A Feature represents a geographical feature
     specified as a cartopy Feature type.
     """
 
@@ -190,8 +186,7 @@ class Feature(_GeoFeature):
         return self.clone().opts(*args, **kwargs)
 
     def geoms(self, scale=None, bounds=None, as_element=True):
-        """
-        Returns the geometries held by the Feature.
+        """Returns the geometries held by the Feature.
 
         Parameters
         ----------
@@ -247,8 +242,7 @@ class Feature(_GeoFeature):
 
 
 class WMTS(_GeoFeature):
-    """
-    The WMTS Element represents a Web Map Tile Service specified as URL
+    """The WMTS Element represents a Web Map Tile Service specified as URL
     containing different template variables or xyzservices.TileProvider.
 
     These variables correspond to three different formats for specifying the spatial
@@ -290,8 +284,7 @@ class WMTS(_GeoFeature):
 
 
 class Tiles(WMTS):
-    """
-    Tiles represents an image tile source to dynamically
+    """Tiles represents an image tile source to dynamically
     load data from depending on the zoom level.
     """
 
@@ -299,8 +292,7 @@ class Tiles(WMTS):
 
 
 class Dataset(_Element, HvDataset):
-    """
-    Coordinate system aware version of a HoloViews dataset.
+    """Coordinate system aware version of a HoloViews dataset.
     """
 
     kdims = param.List(default=[Dimension('Longitude'), Dimension('Latitude')],
@@ -311,20 +303,18 @@ class Dataset(_Element, HvDataset):
 
 
 class Points(_Element, HvPoints):
-    """
-    Points represent a collection of points with
+    """Points represent a collection of points with
     an associated cartopy coordinate-reference system.
     """
 
     group = param.String(default='Points')
 
     def geom(self, union=False, projection=None):
-        """
-        Converts the Points to a shapely geometry.
+        """Converts the Points to a shapely geometry.
 
         Parameters
         ----------
-        union: boolean (default=False)
+        union: boolean, default=False
             Whether to compute a union between the geometries
         projection : EPSG string | Cartopy CRS | None
             Whether to project the geometry to other coordinate system
@@ -347,8 +337,7 @@ class Points(_Element, HvPoints):
 
 
 class HexTiles(_Element, HvHexTiles):
-    """
-    Points represent a collection of points with
+    """Points represent a collection of points with
     an associated cartopy coordinate-reference system.
     """
 
@@ -357,8 +346,7 @@ class HexTiles(_Element, HvHexTiles):
 
 
 class Labels(_Element, HvLabels):
-    """
-    Points represent a collection of points with
+    """Points represent a collection of points with
     an associated cartopy coordinate-reference system.
     """
 
@@ -366,8 +354,7 @@ class Labels(_Element, HvLabels):
 
 
 class VectorField(_Element, HvVectorField):
-    """
-    A VectorField contains is a collection of vectors where each
+    """A VectorField contains is a collection of vectors where each
     vector has an associated position. The vectors should be specified
     by defining an angle in radians and a magnitude.
     """
@@ -417,8 +404,7 @@ class WindBarbs(_Element, Selection2DExpr, HvGeometry):
 
 
 class Image(_Element, HvImage):
-    """
-    Image represents a 2D array of some quantity with
+    """Image represents a 2D array of some quantity with
     some associated coordinates.
     """
 
@@ -433,8 +419,7 @@ class Image(_Element, HvImage):
 
 
 class ImageStack(_Element, HvImageStack):
-    """
-    ImageStack expands the capabilities of Image to by supporting
+    """ImageStack expands the capabilities of Image to by supporting
     multiple layers of images.
 
     As there is many ways to represent multiple layers of images,
@@ -472,8 +457,7 @@ class ImageStack(_Element, HvImageStack):
 
 
 class QuadMesh(_Element, HvQuadMesh):
-    """
-    QuadMesh is a Raster type to hold x- and y- bin values
+    """QuadMesh is a Raster type to hold x- and y- bin values
     with associated values. The x- and y-values of the QuadMesh
     may be supplied either as the edges of each bin allowing
     uneven sampling or as the bin centers, which will be converted
@@ -508,8 +492,7 @@ class QuadMesh(_Element, HvQuadMesh):
 
 
 class LineContours(QuadMesh):
-    """
-    LineContours represents a 2D array of some quantity with
+    """LineContours represents a 2D array of some quantity with
     some associated coordinates, which may be discretized
     into one or more line contours.
     """
@@ -518,8 +501,7 @@ class LineContours(QuadMesh):
 
 
 class FilledContours(QuadMesh):
-    """
-    Contours represents a 2D array of some quantity with
+    """Contours represents a 2D array of some quantity with
     some associated coordinates, which may be discretized
     into one or more filled contours.
     """
@@ -528,8 +510,7 @@ class FilledContours(QuadMesh):
 
 
 class RGB(_Element, HvRGB):
-    """
-    An RGB element is a Image containing channel data for the the
+    """An RGB element is a Image containing channel data for the the
     red, green, blue and (optionally) the alpha channels. The values
     of each channel must be in the range 0.0 to 1.0.
 
@@ -552,8 +533,7 @@ class RGB(_Element, HvRGB):
     @classmethod
     def from_xarray(cls, da, crs=None, apply_transform=False,
                     nan_nodata=False, **kwargs):
-        """
-        Returns an RGB or Image element given an xarray DataArray
+        """Returns an RGB or Image element given an xarray DataArray
         loaded using xr.open_rasterio.
 
         If a crs attribute is present on the loaded data it will
@@ -575,15 +555,15 @@ class RGB(_Element, HvRGB):
 
         Returns
         -------
-        element: Image/RGB/QuadMesh element
+        element
+            Image/RGB/QuadMesh element
         """
         return from_xarray(da, crs, apply_transform, **kwargs)
 
 
 
 class Nodes(_Element, HvNodes):
-    """
-    Nodes is a simple Element representing Graph nodes as a set of
+    """Nodes is a simple Element representing Graph nodes as a set of
     Points.  Unlike regular Points, Nodes must define a third key
     dimension corresponding to the node index.
     """
@@ -596,27 +576,24 @@ class Nodes(_Element, HvNodes):
 
 
 class Text(HvText, _Element):
-    """
-    An annotation containing some text at an x, y coordinate
+    """An annotation containing some text at an x, y coordinate
     along with a coordinate reference system.
     """
 
 
 class Path(_Element, HvPath):
-    """
-    The Path Element contains a list of Paths stored as Nx2 numpy
+    """The Path Element contains a list of Paths stored as Nx2 numpy
     arrays along with a coordinate reference system.
     """
 
     group = param.String(default='Path', constant=True)
 
     def geom(self, union=False, projection=None):
-        """
-        Converts the Path to a shapely geometry.
+        """Converts the Path to a shapely geometry.
 
         Parameters
         ----------
-        union: boolean (default=False)
+        union: boolean, default=False
             Whether to compute a union between the geometries
         projection : EPSG string | Cartopy CRS | None
             Whether to project the geometry to other coordinate system
@@ -639,8 +616,7 @@ class Path(_Element, HvPath):
 
 
 class EdgePaths(Path):
-    """
-    EdgePaths is a simple Element representing the paths of edges
+    """EdgePaths is a simple Element representing the paths of edges
     connecting nodes in a graph.
     """
 
@@ -689,8 +665,7 @@ class Graph(_Element, HvGraph):
 
     @property
     def edgepaths(self):
-        """
-        Returns the fixed EdgePaths or computes direct connections
+        """Returns the fixed EdgePaths or computes direct connections
         between supplied nodes.
         """
         edgepaths = super().edgepaths
@@ -741,8 +716,7 @@ class TriMesh(HvTriMesh, Graph):
 
     @property
     def edgepaths(self):
-        """
-        Returns the fixed EdgePaths or computes direct connections
+        """Returns the fixed EdgePaths or computes direct connections
         between supplied nodes.
         """
         edgepaths = super().edgepaths
@@ -751,8 +725,7 @@ class TriMesh(HvTriMesh, Graph):
 
 
 class Contours(_Element, HvContours):
-    """
-    Contours is a Path Element type that may contain any number of
+    """Contours is a Path Element type that may contain any number of
     closed paths with an associated value and a coordinate reference
     system.
     """
@@ -760,12 +733,11 @@ class Contours(_Element, HvContours):
     group = param.String(default='Contours', constant=True)
 
     def geom(self, union=False, projection=None):
-        """
-        Converts the Contours to a shapely geometry.
+        """Converts the Contours to a shapely geometry.
 
         Parameters
         ----------
-        union: boolean (default=False)
+        union: boolean, default=False
             Whether to compute a union between the geometries
         projection : EPSG string | Cartopy CRS | None
             Whether to project the geometry to other coordinate system
@@ -788,8 +760,7 @@ class Contours(_Element, HvContours):
 
 
 class Polygons(_Element, HvPolygons):
-    """
-    Polygons is a Path Element type that may contain any number of
+    """Polygons is a Path Element type that may contain any number of
     closed paths with an associated value and a coordinate reference
     system.
     """
@@ -797,12 +768,11 @@ class Polygons(_Element, HvPolygons):
     group = param.String(default='Polygons', constant=True)
 
     def geom(self, union=False, projection=None):
-        """
-        Converts the Path to a shapely geometry.
+        """Converts the Path to a shapely geometry.
 
         Parameters
         ----------
-        union: boolean (default=False)
+        union: boolean, default=False
             Whether to compute a union between the geometries
         projection : EPSG string | Cartopy CRS | None
             Whether to project the geometry to other coordinate system
@@ -825,8 +795,7 @@ class Polygons(_Element, HvPolygons):
 
 
 class Rectangles(_Element, HvRectangles):
-    """
-    Rectangles represent a collection of axis-aligned rectangles in 2D space.
+    """Rectangles represent a collection of axis-aligned rectangles in 2D space.
     """
 
     group = param.String(default='Rectangles', constant=True)
@@ -839,12 +808,11 @@ class Rectangles(_Element, HvRectangles):
         of each box.""")
 
     def geom(self, union=False, projection=None):
-        """
-        Converts the Rectangles to a shapely geometry.
+        """Converts the Rectangles to a shapely geometry.
 
         Parameters
         ----------
-        union: boolean (default=False)
+        union: boolean, default=False
             Whether to compute a union between the geometries
         projection : EPSG string | Cartopy CRS | None
             Whether to project the geometry to other coordinate system
@@ -867,8 +835,7 @@ class Rectangles(_Element, HvRectangles):
 
 
 class Segments(_Element, HvSegments):
-    """
-    Segments represent a collection of lines in 2D space.
+    """Segments represent a collection of lines in 2D space.
     """
 
     group = param.String(default='Segments', constant=True)
@@ -881,8 +848,7 @@ class Segments(_Element, HvSegments):
         of each segment.""")
 
     def geom(self, union=False, projection=None):
-        """
-        Converts the Segments to a shapely geometry.
+        """Converts the Segments to a shapely geometry.
         """
         lines = [LineString([(x0, y0), (x1, y1)]) for (x0, y0, x1, y1)
                  in self.array([0, 1, 2, 3])]
@@ -899,8 +865,7 @@ class Segments(_Element, HvSegments):
 
 
 class Shape(Dataset):
-    """
-    Shape wraps any shapely geometry type.
+    """Shape wraps any shapely geometry type.
     """
 
     group = param.String(default='Shape')
@@ -929,8 +894,7 @@ class Shape(Dataset):
 
     @classmethod
     def from_shapefile(cls, shapefile, *args, **kwargs):
-        """
-        Loads a shapefile from disk and optionally merges
+        """Loads a shapefile from disk and optionally merges
         it with a dataset. See ``from_records`` for full
         signature.
 
@@ -965,8 +929,7 @@ class Shape(Dataset):
     @classmethod
     def from_records(cls, records, dataset=None, on=None, value=None,
                      index=None, drop_missing=False, element=None, **kwargs):
-        """
-        Load data from a collection of `cartopy.io.shapereader.Record`
+        """Load data from a collection of `cartopy.io.shapereader.Record`
         objects and optionally merge it with a dataset to assign
         values to each polygon and form a chloropleth. Supplying just
         records will return an NdOverlayof Shape Elements with a
@@ -1080,12 +1043,11 @@ class Shape(Dataset):
 
 
     def geom(self, union=False, projection=None):
-        """
-        Returns the Shape as a shapely geometry
+        """Returns the Shape as a shapely geometry
 
         Parameters
         ----------
-        union: boolean (default=False)
+        union: boolean, default=False
             Whether to compute a union between the geometries
         projection : EPSG string | Cartopy CRS | None
             Whether to project the geometry to other coordinate system

--- a/geoviews/element/geo.py
+++ b/geoviews/element/geo.py
@@ -190,7 +190,7 @@ class Feature(_GeoFeature):
 
         Parameters
         ----------
-        scale: str
+        scale : str
           Scale of the geometry to return expressed as string.
           Available scales depends on the Feature type.
 
@@ -200,14 +200,14 @@ class Feature(_GeoFeature):
           GSHHSFeature:
            'auto', 'coarse', 'low', 'intermediate', 'high', 'full'
 
-        bounds: tuple
+        bounds : tuple
           Tuple of a bounding region to query for geometries in
-        as_element: boolean
+        as_element : boolean
           Whether to wrap the geometries in an element
 
         Returns
         -------
-        geometries: Polygons/Path
+        geometries : Polygons/Path
           Polygons or Path object wrapping around returned geometries
         """
         feature = self.data
@@ -314,7 +314,7 @@ class Points(_Element, HvPoints):
 
         Parameters
         ----------
-        union: boolean, default=False
+        union : boolean, default=False
             Whether to compute a union between the geometries
         projection : EPSG string | Cartopy CRS | None
             Whether to project the geometry to other coordinate system
@@ -542,15 +542,15 @@ class RGB(_Element, HvRGB):
 
         Parameters
         ----------
-        da: xarray.DataArray
+        da : xarray.DataArray
           DataArray to convert to element
-        crs: Cartopy CRS or EPSG string (optional)
+        crs : Cartopy CRS or EPSG string (optional)
           Overrides CRS inferred from the data
-        apply_transform: boolean
+        apply_transform : boolean
           Whether to apply affine transform if defined on the data
-        nan_nodata: boolean
+        nan_nodata : boolean
           If data contains nodata values convert them to NaNs
-        **kwargs:
+        **kwargs :
           Keyword arguments passed to the HoloViews/GeoViews element
 
         Returns
@@ -593,7 +593,7 @@ class Path(_Element, HvPath):
 
         Parameters
         ----------
-        union: boolean, default=False
+        union : boolean, default=False
             Whether to compute a union between the geometries
         projection : EPSG string | Cartopy CRS | None
             Whether to project the geometry to other coordinate system
@@ -737,7 +737,7 @@ class Contours(_Element, HvContours):
 
         Parameters
         ----------
-        union: boolean, default=False
+        union : boolean, default=False
             Whether to compute a union between the geometries
         projection : EPSG string | Cartopy CRS | None
             Whether to project the geometry to other coordinate system
@@ -772,7 +772,7 @@ class Polygons(_Element, HvPolygons):
 
         Parameters
         ----------
-        union: boolean, default=False
+        union : boolean, default=False
             Whether to compute a union between the geometries
         projection : EPSG string | Cartopy CRS | None
             Whether to project the geometry to other coordinate system
@@ -812,7 +812,7 @@ class Rectangles(_Element, HvRectangles):
 
         Parameters
         ----------
-        union: boolean, default=False
+        union : boolean, default=False
             Whether to compute a union between the geometries
         projection : EPSG string | Cartopy CRS | None
             Whether to project the geometry to other coordinate system
@@ -900,26 +900,26 @@ class Shape(Dataset):
 
         Parameters
         ----------
-        records: list of cartopy.io.shapereader.Record
+        records : list of cartopy.io.shapereader.Record
            Iterator containing Records.
-        dataset: holoviews.Dataset
+        dataset : holoviews.Dataset
            Any HoloViews Dataset type.
-        on: str or list or dict
+        on : str or list or dict
           A mapping between the attribute names in the records and the
           dimensions in the dataset.
-        value: str
+        value : str
           The value dimension in the dataset the values will be drawn
           from.
-        index: str or list
+        index : str or list
           One or more dimensions in the dataset the Shapes will be
           indexed by.
-        drop_missing: boolean
+        drop_missing : boolean
           Whether to drop shapes which are missing from the provides
           dataset.
 
         Returns
         -------
-        shapes: Polygons or Path object
+        shapes : Polygons or Path object
           A Polygons or Path object containing the geometries
         """
         reader = Reader(shapefile)
@@ -942,26 +942,26 @@ class Shape(Dataset):
 
         Parameters
         ----------
-        records: list of cartopy.io.shapereader.Record
+        records : list of cartopy.io.shapereader.Record
            Iterator containing Records.
-        dataset: holoviews.Dataset
+        dataset : holoviews.Dataset
            Any HoloViews Dataset type.
-        on: str or list or dict
+        on : str or list or dict
           A mapping between the attribute names in the records and the
           dimensions in the dataset.
-        value: str
+        value : str
           The value dimension in the dataset the values will be drawn
           from.
-        index: str or list
+        index : str or list
           One or more dimensions in the dataset the Shapes will be
           indexed by.
-        drop_missing: boolean
+        drop_missing : boolean
           Whether to drop shapes which are missing from the provides
           dataset.
 
         Returns
         -------
-        shapes: Polygons or Path object
+        shapes : Polygons or Path object
           A Polygons or Path object containing the geometries
         """
         if index is None:
@@ -1047,7 +1047,7 @@ class Shape(Dataset):
 
         Parameters
         ----------
-        union: boolean, default=False
+        union : boolean, default=False
             Whether to compute a union between the geometries
         projection : EPSG string | Cartopy CRS | None
             Whether to project the geometry to other coordinate system

--- a/geoviews/links.py
+++ b/geoviews/links.py
@@ -8,8 +8,7 @@ from holoviews.plotting.links import Link, RectanglesTableLink as HvRectanglesTa
 
 
 class PointTableLink(Link):
-    """
-    Defines a Link between a Points type and a Table which will
+    """Defines a Link between a Points type and a Table which will
     display the projected coordinates.
     """
 
@@ -25,8 +24,7 @@ class PointTableLink(Link):
 
 
 class VertexTableLink(Link):
-    """
-    Defines a Link between a Path type and a Table which will
+    """Defines a Link between a Path type and a Table which will
     display the vertices of selected path.
     """
 
@@ -42,9 +40,7 @@ class VertexTableLink(Link):
 
 
 class RectanglesTableLink(HvRectanglesTableLink):
-    """
-    Links a Rectangles element to a Table.
-    """
+    """Links a Rectangles element to a Table."""
 
 
 class PointTableLinkCallback(LinkCallback):

--- a/geoviews/models/custom_tools.py
+++ b/geoviews/models/custom_tools.py
@@ -25,8 +25,7 @@ class _BokehCheck(Tool):
 
 
 class CheckpointTool(_BokehCheck, Tool):
-    """
-    Checkpoints the data on the supplied ColumnDataSources, allowing
+    """Checkpoints the data on the supplied ColumnDataSources, allowing
     the RestoreTool to restore the data to a previous state.
     """
 
@@ -34,8 +33,7 @@ class CheckpointTool(_BokehCheck, Tool):
 
 
 class RestoreTool(_BokehCheck, Tool):
-    """
-    Restores the data on the supplied ColumnDataSources to a previous
+    """Restores the data on the supplied ColumnDataSources to a previous
     checkpoint created by the CheckpointTool
     """
 
@@ -43,9 +41,7 @@ class RestoreTool(_BokehCheck, Tool):
 
 
 class ClearTool(_BokehCheck, Tool):
-    """
-    Clears the data on the supplied ColumnDataSources.
-    """
+    """Clears the data on the supplied ColumnDataSources."""
 
     sources = List(Instance(ColumnDataSource))
 

--- a/geoviews/operation/__init__.py
+++ b/geoviews/operation/__init__.py
@@ -27,8 +27,7 @@ except ImportError:
     pass
 
 def convert_to_geotype(element, crs=None):
-    """
-    Converts a HoloViews element type to the equivalent GeoViews
+    """Converts a HoloViews element type to the equivalent GeoViews
     element if given a coordinate reference system.
     """
     geotype = getattr(gv_element, type(element).__name__, None)
@@ -38,8 +37,7 @@ def convert_to_geotype(element, crs=None):
 
 
 def find_crs(op, element):
-    """
-    Traverses the supplied object looking for coordinate reference
+    """Traverses the supplied object looking for coordinate reference
     systems (crs). If multiple clashing reference systems are found
     it will throw an error.
     """
@@ -55,8 +53,7 @@ def find_crs(op, element):
 
 
 def add_crs(op, element, **kwargs):
-    """
-    Converts any elements in the input to their equivalent geotypes
+    """Converts any elements in the input to their equivalent geotypes
     if given a coordinate reference system.
     """
     return element.map(lambda x: convert_to_geotype(x, kwargs.get('crs')), Element)

--- a/geoviews/operation/projection.py
+++ b/geoviews/operation/projection.py
@@ -40,8 +40,7 @@ from ..util import (
 
 
 class _project_operation(Operation):
-    """
-    Baseclass for projection operations, projecting elements from their
+    """Baseclass for projection operations, projecting elements from their
     source coordinate reference system to the supplied projection.
     """
 
@@ -58,8 +57,7 @@ class _project_operation(Operation):
 
 
 class project_path(_project_operation):
-    """
-    Projects Polygons and Path Elements from their source coordinate
+    """Projects Polygons and Path Elements from their source coordinate
     reference system to the supplied projection.
     """
 
@@ -153,8 +151,7 @@ class project_path(_project_operation):
 
 
 class project_shape(_project_operation):
-    """
-    Projects Shape Element from the source coordinate reference system
+    """Projects Shape Element from the source coordinate reference system
     to the supplied projection.
     """
 
@@ -368,8 +365,7 @@ class project_quadmesh(_project_operation):
 
 
 class project_image(_project_operation):
-    """
-    Projects an geoviews Image to the specified projection,
+    """Projects an geoviews Image to the specified projection,
     returning a regular HoloViews Image type. Works by
     regridding the data along projected bounds. Only supports
     rectangular projections.
@@ -500,9 +496,7 @@ class project_image(_project_operation):
 
 
 class project(Operation):
-    """
-    Projects GeoViews Element types to the specified projection.
-    """
+    """Projects GeoViews Element types to the specified projection."""
 
     projection = param.ClassSelector(default=ccrs.GOOGLE_MERCATOR,
                                      class_=ccrs.Projection,

--- a/geoviews/operation/regrid.py
+++ b/geoviews/operation/regrid.py
@@ -12,8 +12,7 @@ from ..element import Image, QuadMesh, is_geographic
 
 
 class weighted_regrid(regrid):
-    """
-    Implements weighted regridding of rectilinear and curvilinear
+    """Implements weighted regridding of rectilinear and curvilinear
     grids using the xESMF library, supporting all the ESMF regridding
     algorithms including bilinear, conservative and nearest neighbour
     regridding. The operation will always store the sparse weight
@@ -125,9 +124,7 @@ class weighted_regrid(regrid):
 
     @classmethod
     def clean_weight_files(cls):
-        """
-        Cleans existing weight files.
-        """
+        """Cleans existing weight files."""
         deleted = []
         for f in cls._files:
             try:

--- a/geoviews/operation/resample.py
+++ b/geoviews/operation/resample.py
@@ -9,8 +9,7 @@ from ..util import path_to_geom_dicts, polygons_to_geom_dicts, shapely_v2
 
 
 def find_geom(geom, geoms):
-    """
-    Returns the index of a geometry in a list of geometries avoiding
+    """Returns the index of a geometry in a list of geometries avoiding
     expensive equality checks of `in` operator.
     """
     for i, g in enumerate(geoms):
@@ -18,8 +17,7 @@ def find_geom(geom, geoms):
             return i
 
 def compute_zoom_level(bounds, domain, levels):
-    """
-    Computes a zoom level given a bounds polygon, a polygon of the
+    """Computes a zoom level given a bounds polygon, a polygon of the
     overall domain and the number of zoom levels to divide the data
     into.
 
@@ -42,8 +40,7 @@ def compute_zoom_level(bounds, domain, levels):
 
 
 def bounds_to_poly(bounds):
-    """
-    Constructs a shapely Polygon from the provided bounds tuple.
+    """Constructs a shapely Polygon from the provided bounds tuple.
 
     Parameters
     ----------
@@ -60,8 +57,7 @@ def bounds_to_poly(bounds):
 
 
 class resample_geometry(Operation):
-    """
-    This operation dynamically culls and resamples Path or Polygons
+    """This operation dynamically culls and resamples Path or Polygons
     elements based on the current zoom level. On first execution a
     RTree is created using the Sort-Tile-Recursive algorithm, which is
     used to query for geometries within the current viewport (defined

--- a/geoviews/operation/resample.py
+++ b/geoviews/operation/resample.py
@@ -23,16 +23,16 @@ def compute_zoom_level(bounds, domain, levels):
 
     Parameters
     ----------
-    bounds: shapely.geometry.Polygon
+    bounds : shapely.geometry.Polygon
         Polygon representing the area of the current viewport
-    domain: shapely.geometry.Polygon
+    domain : shapely.geometry.Polygon
         Polygon representing the overall bounding region of the data
-    levels: int
+    levels : int
         Number of zoom levels to divide the domain into
 
     Returns
     -------
-    zoom_level: int
+    zoom_level : int
         Integer zoom level
     """
     area_fraction = min(bounds.area/domain.area, 1)
@@ -44,12 +44,12 @@ def bounds_to_poly(bounds):
 
     Parameters
     ----------
-    bounds: tuple
+    bounds : tuple
         Tuple representing the (left, bottom, right, top) coordinates
 
     Returns
     -------
-    polygon: shapely.geometry.Polygon
+    polygon : shapely.geometry.Polygon
         Shapely Polygon geometry of the bounds
     """
     x0, y0, x1, y1 = bounds

--- a/geoviews/plotting/bokeh/__init__.py
+++ b/geoviews/plotting/bokeh/__init__.py
@@ -137,9 +137,7 @@ class TilePlot(GeoPlot):
                            if k in renderer.properties()})
 
     def _init_glyph(self, plot, mapping, properties):
-        """
-        Returns a Bokeh glyph object.
-        """
+        """Returns a Bokeh glyph object."""
         tile_source = mapping['tile_source']
         level = properties.pop('level', 'underlay')
         renderer = plot.add_tile(tile_source, level=level)
@@ -207,18 +205,14 @@ class GeoContourPlot(GeoPlot, ContourPlot):
 
 
 class LineContourPlot(GeoContourPlot):
-    """
-    Draws a contour plot.
-    """
+    """Draws a contour plot."""
 
     levels = param.ClassSelector(default=10, class_=(list, int), doc="""
         A list of scalar values used to specify the contour levels.""")
 
 
 class FilledContourPlot(GeoPolygonPlot):
-    """
-    Draws a filled contour plot.
-    """
+    """Draws a filled contour plot."""
 
     levels = param.ClassSelector(default=10, class_=(list, int), doc="""
         A list of scalar values used to specify the contour levels.""")
@@ -319,8 +313,7 @@ class GeoLabelsPlot(GeoPlot, LabelsPlot):
 
 
 class geo_hex_binning(hex_binning, project_points):
-    """
-    Applies hex binning by computing aggregates on a hexagonal grid.
+    """Applies hex binning by computing aggregates on a hexagonal grid.
 
     Should not be user facing as the returned element is not directly
     usable.

--- a/geoviews/plotting/bokeh/callbacks.py
+++ b/geoviews/plotting/bokeh/callbacks.py
@@ -59,9 +59,7 @@ from .plot import GeoOverlayPlot
 
 
 def get_cb_plot(cb, plot=None):
-    """
-    Finds the subplot with the corresponding stream.
-    """
+    """Finds the subplot with the corresponding stream."""
     plot = plot or cb.plot
     if isinstance(plot, GeoOverlayPlot):
         plots = [get_cb_plot(cb, p) for p in plot.subplots.values()]
@@ -73,9 +71,7 @@ def get_cb_plot(cb, plot=None):
 
 
 def skip(cb, msg, attributes):
-    """
-    Skips applying transforms if data is not geographic.
-    """
+    """Skips applying transforms if data is not geographic."""
     if not all(a in msg for a in attributes):
         return True
     plot = get_cb_plot(cb)
@@ -84,9 +80,7 @@ def skip(cb, msg, attributes):
 
 
 def project_ranges(cb, msg, attributes):
-    """
-    Projects ranges supplied by a callback.
-    """
+    """Projects ranges supplied by a callback."""
     if skip(cb, msg, attributes):
         return msg
 
@@ -105,9 +99,7 @@ def project_ranges(cb, msg, attributes):
 
 
 def project_point(cb, msg, attributes=('x', 'y')):
-    """
-    Projects a single point supplied by a callback
-    """
+    """Projects a single point supplied by a callback."""
     if skip(cb, msg, attributes): return msg
     plot = get_cb_plot(cb)
     x, y = msg.get('x', 0), msg.get('y', 0)
@@ -118,9 +110,7 @@ def project_point(cb, msg, attributes=('x', 'y')):
 
 
 def project_drawn(cb, msg):
-    """
-    Projects a drawn element to the declared coordinate system
-    """
+    """Projects a drawn element to the declared coordinate system."""
     stream = cb.streams[0]
     old_data = stream.data
     stream.update(data=msg['data'])

--- a/geoviews/plotting/bokeh/plot.py
+++ b/geoviews/plotting/bokeh/plot.py
@@ -14,9 +14,7 @@ from ..plot import ProjectionPlot
 
 
 class GeoPlot(ProjectionPlot, ElementPlot):
-    """
-    Plotting baseclass for geographic plots with a cartopy projection.
-    """
+    """Plotting baseclass for geographic plots with a cartopy projection."""
 
     default_tools = param.List(default=['save', 'pan',
                                         WheelZoomTool(zoom_on_axis=False),
@@ -105,9 +103,7 @@ class GeoPlot(ProjectionPlot, ElementPlot):
                 ax_range.min_interval = min_interval
 
     def _set_unwrap_lons(self, element, ranges):
-        """
-        Check whether the lons should be transformed from 0, 360 to -180, 180
-        """
+        """Check whether the lons should be transformed from 0, 360 to -180, 180."""
         if isinstance(self.geographic, _CylindricalProjection):
             xdim = element.get_dimension(0)
             x_range = ranges.get(xdim.name, {}).get('data')
@@ -192,8 +188,7 @@ class GeoPlot(ProjectionPlot, ElementPlot):
 
 
 class GeoOverlayPlot(GeoPlot, HvOverlayPlot):
-    """
-    Subclasses the HoloViews OverlayPlot to add custom behavior
+    """Subclasses the HoloViews OverlayPlot to add custom behavior
     for geographic plots.
     """
 

--- a/geoviews/plotting/mpl/__init__.py
+++ b/geoviews/plotting/mpl/__init__.py
@@ -80,8 +80,7 @@ from .chart import WindBarbsPlot
 
 
 class LayoutPlot(ProjectionPlot, HvLayoutPlot):
-    """
-    Extends HoloViews LayoutPlot with functionality to determine
+    """Extends HoloViews LayoutPlot with functionality to determine
     the correct projection for each axis.
     """
 
@@ -94,8 +93,7 @@ class LayoutPlot(ProjectionPlot, HvLayoutPlot):
 
 
 class GeoOverlayPlot(ProjectionPlot, HvOverlayPlot):
-    """
-    Extends HoloViews OverlayPlot with functionality to determine
+    """Extends HoloViews OverlayPlot with functionality to determine
     the correct projection for each axis.
     """
 
@@ -134,9 +132,7 @@ class GeoOverlayPlot(ProjectionPlot, HvOverlayPlot):
 
 
 class GeoPlot(ProjectionPlot, ElementPlot):
-    """
-    Plotting baseclass for geographic plots with a cartopy projection.
-    """
+    """Plotting baseclass for geographic plots with a cartopy projection."""
 
     apply_ranges = param.Boolean(default=False, doc="""
         Do not use ranges to compute plot extents by default.""")
@@ -242,9 +238,7 @@ class GeoPlot(ProjectionPlot, ElementPlot):
         return super().get_data(element, ranges, style)
 
     def teardown_handles(self):
-        """
-        Delete artist handle so it can be redrawn.
-        """
+        """Delete artist handle so it can be redrawn."""
         try:
             self.handles['artist'].remove()
         except ValueError:
@@ -253,9 +247,7 @@ class GeoPlot(ProjectionPlot, ElementPlot):
 
 
 class GeoImagePlot(GeoPlot, RasterPlot):
-    """
-    Draws a pcolormesh plot from the data in a Image Element.
-    """
+    """Draws a pcolormesh plot from the data in a Image Element."""
 
     style_opts = ['alpha', 'cmap', 'visible', 'filterrad', 'clims', 'norm']
 
@@ -276,9 +268,7 @@ class GeoImagePlot(GeoPlot, RasterPlot):
 
 
     def update_handles(self, *args):
-        """
-        Update the elements of the plot.
-        """
+        """Update the elements of the plot."""
         return GeoPlot.update_handles(self, *args)
 
 
@@ -294,9 +284,7 @@ class GeoQuadMeshPlot(GeoPlot, QuadMeshPlot):
 
 
 class GeoRGBPlot(GeoImagePlot):
-    """
-    Draws a imshow plot from the data in a RGB Element.
-    """
+    """Draws a imshow plot from the data in a RGB Element."""
 
     style_opts = ['alpha', 'visible', 'filterrad']
 
@@ -318,16 +306,12 @@ class GeoRGBPlot(GeoImagePlot):
 
 
     def update_handles(self, *args):
-        """
-        Update the elements of the plot.
-        """
+        """Update the elements of the plot."""
         return GeoPlot.update_handles(self, *args)
 
 
 class GeoPointPlot(GeoPlot, PointPlot):
-    """
-    Draws a scatter plot from the data in a Points Element.
-    """
+    """Draws a scatter plot from the data in a Points Element."""
 
     apply_ranges = param.Boolean(default=True)
 
@@ -335,9 +319,7 @@ class GeoPointPlot(GeoPlot, PointPlot):
 
 
 class GeoLabelsPlot(GeoPlot, LabelsPlot):
-    """
-    Draws a scatter plot from the data in a Labels Element.
-    """
+    """Draws a scatter plot from the data in a Labels Element."""
 
     apply_ranges = param.Boolean(default=True)
 
@@ -345,9 +327,7 @@ class GeoLabelsPlot(GeoPlot, LabelsPlot):
 
 
 class GeoHexTilesPlot(GeoPlot, HexTilesPlot):
-    """
-    Draws a scatter plot from the data in a Points Element.
-    """
+    """Draws a scatter plot from the data in a Points Element."""
 
     apply_ranges = param.Boolean(default=True)
 
@@ -355,9 +335,7 @@ class GeoHexTilesPlot(GeoPlot, HexTilesPlot):
 
 
 class GeoVectorFieldPlot(GeoPlot, VectorFieldPlot):
-    """
-    Draws a vector field plot from the data in a VectorField Element.
-    """
+    """Draws a vector field plot from the data in a VectorField Element."""
 
     apply_ranges = param.Boolean(default=True)
 
@@ -365,9 +343,7 @@ class GeoVectorFieldPlot(GeoPlot, VectorFieldPlot):
 
 
 class GeoWindBarbsPlot(GeoPlot, WindBarbsPlot):
-    """
-    Draws a wind barbs plot from the data in a WindBarbs Element.
-    """
+    """Draws a wind barbs plot from the data in a WindBarbs Element."""
 
     apply_ranges = param.Boolean(default=True)
 
@@ -385,9 +361,7 @@ class GeometryPlot(GeoPlot):
 
 
 class GeoPathPlot(GeoPlot, PathPlot):
-    """
-    Draws a Path plot from a Path Element.
-    """
+    """Draws a Path plot from a Path Element."""
 
     apply_ranges = param.Boolean(default=True)
 
@@ -395,9 +369,7 @@ class GeoPathPlot(GeoPlot, PathPlot):
 
 
 class GeoContourPlot(GeoPlot, ContourPlot):
-    """
-    Draws a contour plot from a Contours Element.
-    """
+    """Draws a contour plot from a Contours Element."""
 
     apply_ranges = param.Boolean(default=True)
 
@@ -405,9 +377,7 @@ class GeoContourPlot(GeoPlot, ContourPlot):
 
 
 class GeoPolygonPlot(GeoPlot, PolygonPlot):
-    """
-    Draws a scatter plot from the data in a Points Element.
-    """
+    """Draws a scatter plot from the data in a Points Element."""
 
     apply_ranges = param.Boolean(default=True)
 
@@ -415,9 +385,7 @@ class GeoPolygonPlot(GeoPlot, PolygonPlot):
 
 
 class GeoSegmentPlot(GeoPlot, SegmentPlot):
-    """
-    Draws segments from the data in a the Segments Element.
-    """
+    """Draws segments from the data in a the Segments Element."""
 
     apply_ranges = param.Boolean(default=True)
 
@@ -425,9 +393,7 @@ class GeoSegmentPlot(GeoPlot, SegmentPlot):
 
 
 class GeoRectanglesPlot(GeoPlot, RectanglesPlot):
-    """
-    Draws rectangles from the data in a Rectangles Element.
-    """
+    """Draws rectangles from the data in a Rectangles Element."""
 
     apply_ranges = param.Boolean(default=True)
 
@@ -435,27 +401,21 @@ class GeoRectanglesPlot(GeoPlot, RectanglesPlot):
 
 
 class LineContourPlot(GeoContourPlot):
-    """
-    Draws a contour plot.
-    """
+    """Draws a contour plot."""
 
     levels = param.ClassSelector(default=10, class_=(list, int), doc="""
         A list of scalar values used to specify the contour levels.""")
 
 
 class FilledContourPlot(GeoPolygonPlot):
-    """
-    Draws a filled contour plot.
-    """
+    """Draws a filled contour plot."""
 
     levels = param.ClassSelector(default=10, class_=(list, int), doc="""
         A list of scalar values used to specify the contour levels.""")
 
 
 class GeoShapePlot(GeometryPlot, PolygonPlot):
-    """
-    Draws a scatter plot from the data in a Points Element.
-    """
+    """Draws a scatter plot from the data in a Points Element."""
 
     apply_ranges = param.Boolean(default=True)
 
@@ -495,9 +455,7 @@ class GeoTriMeshPlot(GeoPlot, TriMeshPlot):
 
 
 class FeaturePlot(GeoPlot):
-    """
-    Draws a feature from a Features Element.
-    """
+    """Draws a feature from a Features Element."""
 
     scale = param.Selector(default='110m',
                                  objects=['10m', '50m', '110m'],
@@ -519,9 +477,7 @@ class FeaturePlot(GeoPlot):
 
 
 class WMTSPlot(GeoPlot):
-    """
-    Adds a Web Map Tile Service from a WMTS Element.
-    """
+    """Adds a Web Map Tile Service from a WMTS Element."""
 
     zoom = param.Integer(default=3, doc="""
         Controls the zoom level of the tile source.""")
@@ -549,8 +505,7 @@ class WMTSPlot(GeoPlot):
         return {'artist': ax.add_wmts(*plot_args, **plot_kwargs)}
 
     def teardown_handles(self):
-        """
-        If no custom update_handles method is supplied this method
+        """If no custom update_handles method is supplied this method
         is called to tear down any previous handles before replacing
         them.
         """
@@ -560,9 +515,7 @@ class WMTSPlot(GeoPlot):
 
 
 class GeoAnnotationPlot(AnnotationPlot):
-    """
-    AnnotationPlot handles the display of all annotation elements.
-    """
+    """AnnotationPlot handles the display of all annotation elements."""
 
     def initialize_plot(self, ranges=None):
         annotation = self.hmap.last
@@ -588,7 +541,7 @@ class GeoAnnotationPlot(AnnotationPlot):
 
 
 class GeoTextPlot(GeoAnnotationPlot, TextPlot):
-    "Draw the Text annotation object"
+    """Draw the Text annotation object"""
 
     def draw_annotation(self, axis, data, crs, opts):
         (x, y, text, fontsize,

--- a/geoviews/plotting/mpl/chart.py
+++ b/geoviews/plotting/mpl/chart.py
@@ -6,8 +6,7 @@ from holoviews.util.transform import dim
 
 
 class WindBarbsPlot(ColorbarPlot):
-    """
-    Barbs are traditionally used in meteorology as a way to plot the speed and
+    """Barbs are traditionally used in meteorology as a way to plot the speed and
     direction of wind observations, but can technically be used to plot any two
     dimensional vector quantity. As opposed to arrows, which give vector
     magnitude by the length of the arrow, the barbs give more quantitative

--- a/geoviews/plotting/plot.py
+++ b/geoviews/plotting/plot.py
@@ -6,8 +6,8 @@ from ..util import project_extents
 
 
 def _get_projection(el):
-    """
-    Get coordinate reference system from non-auxiliary elements.
+    """Get coordinate reference system from non-auxiliary elements.
+
     Return value is a tuple of a precedence integer and the projection,
     to allow non-auxiliary components to take precedence.
     """
@@ -18,8 +18,7 @@ def _get_projection(el):
 
 
 class ProjectionPlot(param.Parameterized):
-    """
-    Implements custom _get_projection method to make the coordinate
+    """Implements custom _get_projection method to make the coordinate
     reference system available to HoloViews plots as a projection.
     """
 
@@ -54,8 +53,7 @@ class ProjectionPlot(param.Parameterized):
             return None
 
     def get_extents(self, element, ranges, range_type='combined', **kwargs):
-        """
-        Subclasses the get_extents method using the GeoAxes
+        """Subclasses the get_extents method using the GeoAxes
         set_extent method to project the extents to the
         Elements coordinate reference system.
         """

--- a/geoviews/streams.py
+++ b/geoviews/streams.py
@@ -2,8 +2,7 @@ from holoviews.streams import PolyDraw, PolyEdit
 
 
 class PolyVertexEdit(PolyEdit):
-    """
-    Attaches a PolyVertexEditTool and syncs the datasource.
+    """Attaches a PolyVertexEditTool and syncs the datasource.
 
     shared: boolean
         Whether PolyEditTools should be shared between multiple elements
@@ -26,8 +25,7 @@ class PolyVertexEdit(PolyEdit):
 
 
 class PolyVertexDraw(PolyDraw):
-    """
-    Attaches a PolyVertexDrawTool and syncs the datasource.
+    """Attaches a PolyVertexDrawTool and syncs the datasource.
 
     shared: boolean
         Whether PolyEditTools should be shared between multiple elements

--- a/geoviews/streams.py
+++ b/geoviews/streams.py
@@ -4,13 +4,13 @@ from holoviews.streams import PolyDraw, PolyEdit
 class PolyVertexEdit(PolyEdit):
     """Attaches a PolyVertexEditTool and syncs the datasource.
 
-    shared: boolean
+    shared : boolean
         Whether PolyEditTools should be shared between multiple elements
 
-    node_style: dict
+    node_style : dict
         A dictionary specifying the style options for the intermediate nodes.
 
-    feature_style: dict
+    feature_style : dict
         A dictionary specifying the style options for the intermediate nodes.
     """
 
@@ -27,13 +27,13 @@ class PolyVertexEdit(PolyEdit):
 class PolyVertexDraw(PolyDraw):
     """Attaches a PolyVertexDrawTool and syncs the datasource.
 
-    shared: boolean
+    shared : boolean
         Whether PolyEditTools should be shared between multiple elements
 
-    node_style: dict
+    node_style : dict
         A dictionary specifying the style options for the intermediate nodes.
 
-    feature_style: dict
+    feature_style : dict
         A dictionary specifying the style options for the intermediate nodes.
     """
 

--- a/geoviews/util.py
+++ b/geoviews/util.py
@@ -474,6 +474,7 @@ def proj_to_cartopy(proj):
     ----------
     proj: pyproj.Proj
         the projection to convert
+
     Returns
     -------
     a cartopy.crs.Projection object
@@ -564,10 +565,10 @@ def is_pyproj(crs):
 def process_crs(crs):
     """Parses cartopy CRS definitions defined in one of a few formats:
 
-      1. EPSG codes:   Defined as string of the form "EPSG: {code}" or an integer
-      2. proj.4 string: Defined as string of the form "{proj.4 string}"
-      3. cartopy.crs.CRS instance
-      4. None defaults to crs.PlateCaree
+    1. EPSG codes:   Defined as string of the form "EPSG: {code}" or an integer
+    2. proj.4 string: Defined as string of the form "{proj.4 string}"
+    3. cartopy.crs.CRS instance
+    4. None defaults to crs.PlateCaree
     """
     try:
         import cartopy.crs as ccrs
@@ -727,7 +728,6 @@ def get_tile_rgb(tile_source, bbox, zoom_level, bbox_crs=None):
     -------
     RGB element containing the tile data in the specified bbox
     """
-
     from .element import RGB, WMTS
     if bbox_crs is None:
         bbox_crs = ccrs.PlateCarree()

--- a/geoviews/util.py
+++ b/geoviews/util.py
@@ -33,16 +33,14 @@ shapely_v2 = shapely_version >= Version("2")
 
 
 def wrap_lons(lons, base, period):
-    """
-    Wrap longitude values into the range between base and base+period.
+    """Wrap longitude values into the range between base and base+period.
     """
     lons = lons.astype(np.float64)
     return ((lons - base + period * 2) % period) + base
 
 
 def expand_geoms(geoms):
-    """
-    Expands multi-part geometries in a list of geometries.
+    """Expands multi-part geometries in a list of geometries.
     """
     expanded = []
     for geom in geoms:
@@ -118,8 +116,7 @@ def project_extents(extents, src_proj, dest_proj, tol=1e-6):
 
 
 def zoom_level(bounds, width, height):
-    """
-    Compute zoom level given bounds and the plot size.
+    """Compute zoom level given bounds and the plot size.
     """
     w, s, e, n = bounds
     max_width, max_height = 256, 256
@@ -146,8 +143,7 @@ def zoom_level(bounds, width, height):
 
 
 def geom_dict_to_array_dict(geom_dict, coord_names=None):
-    """
-    Converts a dictionary containing an geometry key to a dictionary
+    """Converts a dictionary containing an geometry key to a dictionary
     of x- and y-coordinate arrays and if present a list-of-lists of
     hole array.
     """
@@ -178,8 +174,7 @@ def geom_dict_to_array_dict(geom_dict, coord_names=None):
 
 
 def unpack_geoms(geom_el):
-    """
-    Unpacks the data in a geometry element if it is already in a
+    """Unpacks the data in a geometry element if it is already in a
     geometry format.
     """
     interface = geom_el.interface
@@ -202,8 +197,7 @@ def unpack_geoms(geom_el):
 
 
 def polygons_to_geom_dicts(polygons, skip_invalid=True):
-    """
-    Converts a Polygons element into a list of geometry dictionaries,
+    """Converts a Polygons element into a list of geometry dictionaries,
     preserving all value dimensions.
 
     For array conversion the following conventions are applied:
@@ -275,8 +269,7 @@ def polygons_to_geom_dicts(polygons, skip_invalid=True):
 
 
 def path_to_geom_dicts(fullpath, skip_invalid=True):
-    """
-    Converts a Path element into a list of geometry dictionaries,
+    """Converts a Path element into a list of geometry dictionaries,
     preserving all value dimensions.
     """
     geoms = unpack_geoms(fullpath)
@@ -321,8 +314,7 @@ def path_to_geom_dicts(fullpath, skip_invalid=True):
 
 
 def to_ccw(geom):
-    """
-    Reorients polygon to be wound counter-clockwise.
+    """Reorients polygon to be wound counter-clockwise.
     """
     if isinstance(geom, sgeom.Polygon) and not geom.exterior.is_ccw:
         geom = sgeom.polygon.orient(geom)
@@ -330,8 +322,7 @@ def to_ccw(geom):
 
 
 def geom_to_arr(geom):
-    """
-    LineString, LinearRing and Polygon (exterior only?)
+    """LineString, LinearRing and Polygon (exterior only?)
     """
     # LineString and LinearRing geoms have an xy attribute
     try:
@@ -359,8 +350,7 @@ def geom_to_arr(geom):
 
 
 def geom_length(geom):
-    """
-    Calculates the length of coordinates in a shapely geometry.
+    """Calculates the length of coordinates in a shapely geometry.
     """
     if geom.geom_type == 'Point':
         return 1
@@ -385,8 +375,7 @@ def geom_length(geom):
 
 
 def geom_to_array(geom):
-    """
-    Convert the coords of a shapely Geometry to a numpy array.
+    """Convert the coords of a shapely Geometry to a numpy array.
     """
     if geom.geom_type == 'Point':
         return np.array([[geom.x, geom.y]])
@@ -417,8 +406,7 @@ def geom_to_array(geom):
 
 
 def geo_mesh(element):
-    """
-    Get mesh data from a 2D Element ensuring that if the data is
+    """Get mesh data from a 2D Element ensuring that if the data is
     on a cylindrical coordinate system and wraps globally that data
     actually wraps around.
     """
@@ -438,15 +426,13 @@ def geo_mesh(element):
 
 
 def is_multi_geometry(geom):
-    """
-    Whether the shapely geometry is a Multi or Collection type.
+    """Whether the shapely geometry is a Multi or Collection type.
     """
     return 'Multi' in geom.geom_type or 'Collection' in geom.geom_type
 
 
 def check_crs(crs):
-    """
-    Checks if the crs represents a valid grid, projection or ESPG string.
+    """Checks if the crs represents a valid grid, projection or ESPG string.
 
     (Code copied from https://github.com/fmaussion/salem)
 
@@ -480,8 +466,7 @@ def check_crs(crs):
 
 
 def proj_to_cartopy(proj):
-    """
-    Converts a pyproj.Proj to a cartopy.crs.Projection
+    """Converts a pyproj.Proj to a cartopy.crs.Projection
 
     (Code copied from https://github.com/fmaussion/salem)
 
@@ -577,8 +562,7 @@ def is_pyproj(crs):
 
 
 def process_crs(crs):
-    """
-    Parses cartopy CRS definitions defined in one of a few formats:
+    """Parses cartopy CRS definitions defined in one of a few formats:
 
       1. EPSG codes:   Defined as string of the form "EPSG: {code}" or an integer
       2. proj.4 string: Defined as string of the form "{proj.4 string}"
@@ -618,8 +602,7 @@ def process_crs(crs):
 
 
 def from_xarray(da, crs=None, apply_transform=False, nan_nodata=False, **kwargs):
-    """
-    Returns an RGB or Image element given an xarray DataArray
+    """Returns an RGB or Image element given an xarray DataArray
     loaded using xr.open_rasterio.
 
     If a crs attribute is present on the loaded data it will
@@ -630,7 +613,7 @@ def from_xarray(da, crs=None, apply_transform=False, nan_nodata=False, **kwargs)
     ----------
     da: xarray.DataArray
       DataArray to convert to element
-    crs: Cartopy CRS or EPSG string (optional)
+    crs: Cartopy CRS or EPSG string, optional
       Overrides CRS inferred from the data
     apply_transform: boolean
       Whether to apply affine transform if defined on the data
@@ -641,7 +624,8 @@ def from_xarray(da, crs=None, apply_transform=False, nan_nodata=False, **kwargs)
 
     Returns
     -------
-    element: Image/RGB/QuadMesh element
+    element
+        Image/RGB/QuadMesh element
     """
     if crs:
         kwargs['crs'] = crs
@@ -725,8 +709,7 @@ def from_xarray(da, crs=None, apply_transform=False, nan_nodata=False, **kwargs)
 
 
 def get_tile_rgb(tile_source, bbox, zoom_level, bbox_crs=None):
-    """
-    Returns an RGB element given a tile_source, bounding box and zoom level.
+    """Returns an RGB element given a tile_source, bounding box and zoom level.
 
     Parameters
     ----------

--- a/geoviews/util.py
+++ b/geoviews/util.py
@@ -472,7 +472,7 @@ def proj_to_cartopy(proj):
 
     Parameters
     ----------
-    proj: pyproj.Proj
+    proj : pyproj.Proj
         the projection to convert
 
     Returns
@@ -565,8 +565,8 @@ def is_pyproj(crs):
 def process_crs(crs):
     """Parses cartopy CRS definitions defined in one of a few formats:
 
-    1. EPSG codes:   Defined as string of the form "EPSG: {code}" or an integer
-    2. proj.4 string: Defined as string of the form "{proj.4 string}"
+    1. EPSG codes :    Defined as string of the form "EPSG: {code}" or an integer
+    2. proj.4 string : Defined as string of the form "{proj.4 string}"
     3. cartopy.crs.CRS instance
     4. None defaults to crs.PlateCaree
     """
@@ -612,15 +612,15 @@ def from_xarray(da, crs=None, apply_transform=False, nan_nodata=False, **kwargs)
 
     Parameters
     ----------
-    da: xarray.DataArray
+    da : xarray.DataArray
       DataArray to convert to element
-    crs: Cartopy CRS or EPSG string, optional
+    crs : Cartopy CRS or EPSG string, optional
       Overrides CRS inferred from the data
-    apply_transform: boolean
+    apply_transform : boolean
       Whether to apply affine transform if defined on the data
-    nan_nodata: boolean
+    nan_nodata : boolean
       If data contains nodata values convert them to NaNs
-    **kwargs:
+    **kwargs :
       Keyword arguments passed to the HoloViews/GeoViews element
 
     Returns
@@ -714,14 +714,14 @@ def get_tile_rgb(tile_source, bbox, zoom_level, bbox_crs=None):
 
     Parameters
     ----------
-    tile_source: WMTS element or string URL
+    tile_source : WMTS element or string URL
       The tile source to download the tiles from.
-    bbox: tuple
+    bbox : tuple
       A four tuple specifying the (left, bottom, right, top) corners of the
       domain to download the tiles for.
-    zoom_level: int
+    zoom_level : int
       The zoom level at which to download the tiles
-    bbox_crs: ccrs.CRs
+    bbox_crs : ccrs.CRs
       cartopy CRS defining the coordinate system of the supplied bbox
 
     Returns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ fix = true
 [tool.ruff.lint]
 select = [
     "B",
+    "D",
     "E",
     "F",
     "FLY",
@@ -127,6 +128,12 @@ ignore = [
     "RUF012", # Mutable class attributes should use `typing.ClassVar`
     'B905', # `zip()` without an explicit `strict=` parameter
     'UP038', # Use `X | Y` in `isinstance` call instead of `(X, Y)`
+    "D1", # Undocumented code
+    "D200", # Unnecessary-multiline-docstring
+    "D205", # Missing-blank-line-after-summary
+    "D400", # Missing-trailing-period
+    "D401", # Non-imperative-mood
+    "D404", # Docstring-starts-with-this
 ]
 
 extend-unsafe-fixes = [
@@ -141,11 +148,15 @@ extend-unsafe-fixes = [
     "RUF002", # Ambiguous unicode character
     "RUF003", # Ambiguous unicode character
     "NPY002", # Replace legacy `np.random.rand` call with Generator
+    "D", # pydocstyle
 ]
 
 [tool.ruff.lint.isort]
 known-first-party = ["geoviews"]
 combine-as-imports = true
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
 
 [tool.codespell]
 ignore-words-list = "lod,nd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,7 @@ ignore = [
     "D400", # Missing-trailing-period
     "D401", # Non-imperative-mood
     "D404", # Docstring-starts-with-this
+    "D419", # Docstring is empty
 ]
 
 extend-unsafe-fixes = [


### PR DESCRIPTION
fixes #788 

- [x] Convert all public API docstrings to use numpydoc format
- [x] Exclude the `tests/` dir
- [x] Configure ruff linting to use numpydoc style 