### PR TITLE
compat: Cartopy 0.25.0

### DIFF
--- a/geoviews/element/geo.py
+++ b/geoviews/element/geo.py
@@ -228,11 +228,22 @@ class Feature(_GeoFeature):
         else:
             return Path(geoms, crs=feature.crs)
 
+    def _data_geometries(self):
+        # First time calling self.data.geometries will try to read
+        # a .prj file and update crs based on it.
+        # This was introduced in Cartopy 0.25.0
+        # https://github.com/SciTools/cartopy/pull/2307
+        before_crs = self.data.crs
+        geometries = self.data.geometries()
+        if self.data.crs != before_crs:
+            self.crs = self.data.crs
+        return geometries
+
     def range(self, dim, data_range=True, dimension_range=True):
         didx = self.get_dimension_index(dim)
         if didx in [0, 1] and data_range:
             dim = self.get_dimension(dim)
-            l, b, r, t = util.max_extents([geom.bounds for geom in self.data.geometries()])
+            l, b, r, t = util.max_extents([geom.bounds for geom in self._data_geometries()])
             lower, upper = (b, t) if didx else (l, r)
             if dimension_range:
                 return util.dimension_range(lower, upper, dim.range, dim.soft_range)

--- a/geoviews/operation/resample.py
+++ b/geoviews/operation/resample.py
@@ -5,7 +5,7 @@ from holoviews.streams import RangeXY
 from shapely.geometry import Polygon
 from shapely.strtree import STRtree
 
-from ..util import path_to_geom_dicts, polygons_to_geom_dicts, shapely_v2
+from ..util import SHAPELY_GE_2_0_0, path_to_geom_dicts, polygons_to_geom_dicts
 
 
 def find_geom(geom, geoms):
@@ -159,7 +159,7 @@ class resample_geometry(Operation):
         # Query RTree, then cull and simplify polygons
         new_geoms, gdict = [], {}
         for g in tree.query(bounds):
-            g = tree.geometries[g] if shapely_v2 else g
+            g = tree.geometries[g] if SHAPELY_GE_2_0_0 else g
             garea = area_cache.get(id(g))
             if garea is None:
                 is_poly = 'Polygon' in g.geom_type

--- a/geoviews/util.py
+++ b/geoviews/util.py
@@ -1,5 +1,6 @@
 from contextlib import suppress
 
+import cartopy
 import numpy as np
 import shapely
 import shapely.geometry as sgeom
@@ -28,8 +29,9 @@ line_types = (MultiLineString, LineString)
 poly_types = (MultiPolygon, Polygon, LinearRing)
 
 
-shapely_version = Version(shapely.__version__)
-shapely_v2 = shapely_version >= Version("2")
+SHAPELY_VERSION = Version(shapely.__version__).release
+SHAPELY_GE_2_0_0 = SHAPELY_VERSION >= (2, 0, 0)
+CARTOPY_VERSION = Version(cartopy.__version__).release
 
 
 def wrap_lons(lons, base, period):
@@ -336,7 +338,7 @@ def geom_to_arr(geom):
     # shapely 1.8.0 deprecated `array_interface` and
     # unfortunately also introduced a bug in the `array_interface_base`
     # property which raised an error as soon as it was called.
-    if shapely_version < Version('1.8.0'):
+    if SHAPELY_VERSION < (1, 8, 0):
         if hasattr(geom, 'array_interface'):
             data = geom.array_interface()
             return np.array(data['data']).reshape(data['shape'])[:, :2]
@@ -358,7 +360,7 @@ def geom_length(geom):
     if hasattr(geom, 'exterior'):
         geom = geom.exterior
     # As of shapely 1.8.0: LineString, LinearRing (and GeometryCollection?)
-    if shapely_version < Version('1.8.0'):
+    if SHAPELY_VERSION < (1, 8, 0):
         if not geom.geom_type.startswith('Multi') and hasattr(geom, 'array_interface_base'):
             return len(geom.array_interface_base['data'])//2
     elif not geom.geom_type.startswith('Multi'):


### PR DESCRIPTION
GeoViews (and hvplot) tests are failing after the release of Cartopy 0.25.0. The failing tests can be reduced down to this MRE:

``` python
import geoviews as gv
import geoviews.feature as gf

gv.extension('bokeh')

features = gf.ocean()
gv.render(features)
features.clone()
```

``` python-traceback
Traceback (most recent call last):
  File "/home/shh/projects/holoviz/repos/geoviews/example.py", line 8, in <module>
    features.clone()
    ~~~~~~~~~~~~~~^^
  File "/home/shh/projects/holoviz/repos/geoviews/geoviews/element/geo.py", line 156, in clone
    return super().clone(data, shared_data, new_type,
           ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                                       *args, **overrides)
                                       ^^^^^^^^^^^^^^^^^^^
  File "/home/shh/projects/holoviz/repos/holoviews/holoviews/core/dimension.py", line 607, in clone
    return clone_type(data, *args, **{k:v for k,v in settings.items()
                                      if k not in pos_args})
  File "/home/shh/projects/holoviz/repos/geoviews/geoviews/element/geo.py", line 183, in __init__
    super().__init__(data, kdims=kdims, vdims=vdims, **params)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/shh/projects/holoviz/repos/geoviews/geoviews/element/geo.py", line 143, in __init__
    raise ValueError('Supplied coordinate reference '
                     'system must match crs of the data.')
ValueError: Supplied coordinate reference system must match crs of the data.
```

This happens because the first time a feature is loaded (with geometries) it tries to update the crs of the feature based on the .prj information.

``` python
from cartopy import feature as cf

print(cf.OCEAN.crs)
cf.OCEAN.geometries()
print(cf.OCEAN.crs)
```

Will output:
```
+proj=eqc +ellps=WGS84 +a=6378137.0 +lon_0=0.0 +to_meter=111319.4907932736 +vto_meter=1 +no_defs +type=crs

GEOGCRS["WGS 84",DATUM["World Geodetic System 1984",ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ID["EPSG",6326]],PRIMEM["Greenwich",0,ANGLEUNIT["Degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["longitude",east,ORDER[1],ANGLEUNIT["Degree",0.0174532925199433]],AXIS["latitude",north,ORDER[2],ANGLEUNIT["Degree",0.0174532925199433]]]
```



