### PR TITLE
Fix projection inconsistency

### DIFF
--- a/geoviews/element/geo.py
+++ b/geoviews/element/geo.py
@@ -417,6 +417,34 @@ class WindBarbs(_Element, Selection2DExpr, HvGeometry):
     vdims = param.List(default=[Dimension('Angle', cyclic=True, range=(0,2*np.pi)),
                                 Dimension('Magnitude')], bounds=(2, None))
 
+    @classmethod
+    def from_uv(cls, data, kdims=None, vdims=None, **params):
+        if kdims is None:
+            kdims = ['x', 'y']
+        if vdims is None:
+            vdims = ['u', 'v']
+        dataset = Dataset(data, kdims=kdims, vdims=vdims, **params)
+        us, vs = (dataset.dimension_values(i) for i in (2, 3))
+
+        uv_magnitudes = np.hypot(us, vs)  # unscaled
+        # using meteorological convention (direction FROM which wind blows)
+        radians = np.pi / 2 - np.arctan2(-vs, -us)
+
+        # calculations on this data could mutate the original data
+        # here we do not do any calculations; we only store the data
+        repackaged_dataset = {}
+        for kdim in kdims:
+            repackaged_dataset[kdim] = dataset[kdim]
+        repackaged_dataset["Angle"] = radians
+        repackaged_dataset["Magnitude"] = uv_magnitudes
+        for vdim in vdims[2:]:
+            repackaged_dataset[vdim] = dataset[vdim]
+        vdims = [
+            Dimension('Angle', cyclic=True, range=(0, 2 * np.pi)),
+            Dimension('Magnitude')
+        ] + vdims[2:]
+        return cls(repackaged_dataset, kdims=kdims, vdims=vdims, **params)
+
 
 class Image(_Element, HvImage):
     """Image represents a 2D array of some quantity with

--- a/geoviews/element/geo.py
+++ b/geoviews/element/geo.py
@@ -374,6 +374,39 @@ class VectorField(_Element, HvVectorField):
     vdims = param.List(default=[Dimension('Angle', cyclic=True, range=(0,2*np.pi)),
                                 Dimension('Magnitude')], bounds=(1, None))
 
+    @classmethod
+    def from_uv(cls, data, kdims=None, vdims=None, **params):
+        """
+        Create a VectorField from u and v components.
+
+        Parameters
+        ----------
+        data : array-like or Dataset
+            Data containing x, y, u, v components
+        kdims : list, optional
+            Key dimensions (default: ['x', 'y'])
+        vdims : list, optional
+            Value dimensions (default: ['u', 'v'])
+        **params : dict
+            Additional parameters, including crs for coordinate reference system
+
+        Returns
+        -------
+        VectorField
+            A VectorField element with angle and magnitude computed from u,v
+
+        Notes
+        -----
+        Uses mathematical convention where angle = arctan2(v, u):
+        - 0 radians points East (positive x direction)
+        - π/2 radians points North (positive y direction)
+        """
+        crs = params.pop('crs', None)
+        vectorfield = super().from_uv(data, kdims=kdims, vdims=vdims, **params)
+        if crs is not None:
+            vectorfield.crs = crs
+        return vectorfield
+
 
 class WindBarbs(_Element, Selection2DExpr, HvGeometry):
     """
@@ -383,34 +416,6 @@ class WindBarbs(_Element, Selection2DExpr, HvGeometry):
 
     vdims = param.List(default=[Dimension('Angle', cyclic=True, range=(0,2*np.pi)),
                                 Dimension('Magnitude')], bounds=(2, None))
-
-    @classmethod
-    def from_uv(cls, data, kdims=None, vdims=None, **params):
-        if kdims is None:
-            kdims = ['x', 'y']
-        if vdims is None:
-            vdims = ['u', 'v']
-        dataset = Dataset(data, kdims=kdims, vdims=vdims, **params)
-        us, vs = (dataset.dimension_values(i) for i in (2, 3))
-
-        uv_magnitudes = np.hypot(us, vs)  # unscaled
-        # using meteorological convention (direction FROM which wind blows)
-        radians = np.pi / 2 - np.arctan2(-vs, -us)
-
-        # calculations on this data could mutate the original data
-        # here we do not do any calculations; we only store the data
-        repackaged_dataset = {}
-        for kdim in kdims:
-            repackaged_dataset[kdim] = dataset[kdim]
-        repackaged_dataset["Angle"] = radians
-        repackaged_dataset["Magnitude"] = uv_magnitudes
-        for vdim in vdims[2:]:
-            repackaged_dataset[vdim] = dataset[vdim]
-        vdims = [
-            Dimension('Angle', cyclic=True, range=(0, 2 * np.pi)),
-            Dimension('Magnitude')
-        ] + vdims[2:]
-        return cls(repackaged_dataset, kdims=kdims, vdims=vdims, **params)
 
 
 class Image(_Element, HvImage):

--- a/geoviews/operation/projection.py
+++ b/geoviews/operation/projection.py
@@ -255,8 +255,8 @@ class project_vectorfield(_project_operation):
         new_data[xdim.name] = coordinates[mask, 0]
         new_data[ydim.name] = coordinates[mask, 1]
         datatype = [element.interface.datatype]+element.datatype
-        us = np.sin(ang) * -ms
-        vs = np.cos(ang) * -ms
+        us = np.cos(ang) * ms
+        vs = np.sin(ang) * ms
         ut, vt = self.p.projection.transform_vectors(element.crs, xs, ys, us, vs)
         with np.errstate(divide='ignore', invalid='ignore'):
             angle = self._calc_angles(ut, vt)


### PR DESCRIPTION
Closes https://github.com/holoviz/geoviews/issues/767

Using matplotlib as the gold standard:
```python
import matplotlib.pyplot as plt
import numpy as np

X = np.arange(-10, 10, 1)
Y = np.arange(-10, 10, 1)
U, V = np.meshgrid(X, Y)

fig, ax = plt.subplots()
q = ax.quiver(X, Y, U, V)
ax.quiverkey(q, X=0.3, Y=1.1, U=10,
             label='Quiver key, length = 10', labelpos='E')
plt.show()
```
<img width="612" height="681" alt="image" src="https://github.com/user-attachments/assets/3cff2850-5191-47fc-8350-d1e96d45a8e8" />
<img width="791" height="1159" alt="image" src="https://github.com/user-attachments/assets/234543cf-6478-4c94-ae3a-a5816aa02c81" />

And also @coding-duck42 example
```python
import panel as pn
import holoviews as hv
import geoviews as gv

import numpy as np
from cartopy import crs as ccrs

hv.extension('matplotlib')

x = np.linspace(-180, 180, 20)
y = np.linspace(-90, 90, 20)

X, Y = np.meshgrid(x, y)

u = 10*np.ones_like(X)
v = np.zeros_like(Y)
projection = ccrs.PlateCarree()
magnitude = np.sqrt(u**2 + v**2)
angle = np.arctan2(v, u)        # Same as in holoviews VectorField.from_uv, np.pi/2 - np.arctan2(-v, -u) is for windbarbs

vectorfield = gv.VectorField((X, Y, angle, magnitude), crs=ccrs.PlateCarree())
vectorfield2 = gv.VectorField.from_uv((X, Y, u, v))
vectorfield3 = hv.VectorField((X, Y, angle, magnitude))
vectorfield4 = hv.VectorField.from_uv((X, Y, u, v))

plot1 = vectorfield.opts(title='gv.VectorField', projection=projection)  # Same issue if you don't project
plot2 = vectorfield2.opts(title='gv.VectorField.from_uv', projection=projection)  # Same issue if you don't project
plot3 = vectorfield3.opts(title='hv.VectorField')
plot4 = vectorfield4.opts(title='hv.VectorField.from_uv')
# gv
pn.Column(pn.Row(plot1, plot2), pn.Row(plot3, plot4)).servable()
```

<img width="788" height="727" alt="image" src="https://github.com/user-attachments/assets/6cb8eb30-a192-45f3-a5e7-a8321b96ce0a" />

As a final sanity check with bokeh, from metpy https://unidata.github.io/MetPy/latest/examples/calculations/Wind_Speed.html


```python
import numpy as np
import geoviews as gv
import xarray as xr
import panel as pn
import metpy.calc as mpcalc
from metpy.cbook import example_data
import cartopy.crs as ccrs
import matplotlib.pyplot as plt

import metpy.calc as mpcalc
from metpy.cbook import example_data

# load example data
ds = example_data()

# Calculate the total deformation of the flow
wind_speed = mpcalc.wind_speed(ds.uwind, ds.vwind)

# start figure and set axis
fig, ax = plt.subplots(figsize=(5, 5))

# plot wind speed
cf = ax.contourf(ds.lon, ds.lat, wind_speed, range(5, 80, 5), cmap=plt.cm.BuPu)
plt.colorbar(cf, pad=0, aspect=50)
ax.quiver(ds.lon.values, ds.lat.values, ds.uwind, ds.vwind, color='black', alpha=0.5)
ax.set(xlim=(260, 270), ylim=(30, 40))
ax.set_title('Wind Speed Calculation')

gv.extension('bokeh')
gv.output(size=200)

# Load example dataset
ds = example_data()

# Calculate wind speed
wind_speed = mpcalc.wind_speed(ds.uwind, ds.vwind)

# Create a GeoViews Image for wind speed
wind_speed_img = gv.Image(
    (ds.lon, ds.lat, wind_speed),
    crs=ccrs.PlateCarree(),
    kdims=['longitude', 'latitude'],
    vdims=['wind_speed'],
).opts(
    cmap='BuPu',
    colorbar=True,
    clim=(5, 80),
    projection=ccrs.PlateCarree(),
    title='Wind Speed Calculation',
    width=500,
    height=500,
)

# Create vector field (barbs)
vector_field = gv.VectorField.from_uv(
    (ds.lon.values, ds.lat.values, ds.uwind.values, ds.vwind.values),
    crs=ccrs.PlateCarree(),
).opts(
    color='black',
    alpha=0.5,
    rescale_lengths=True,
    magnitude=gv.dim('Magnitude').norm()*0.7
)

# Combine and limit extent
pn.Row((wind_speed_img * vector_field), fig)
```
bokeh:
<img width="1217" height="702" alt="image" src="https://github.com/user-attachments/assets/1a5956d9-5135-458c-b2f0-690086d2377a" />

mpl:
<img width="1246" height="634" alt="image" src="https://github.com/user-attachments/assets/c3d96fbd-2bef-4fe4-9d73-1da0184fcaeb" />


cc @TheoMathurin
