### PR TITLE
chore: Fix readme logo to be absolute

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="/doc/_static/logo_stacked.png" width="200"/><br>
+<img src="https://raw.githubusercontent.com/holoviz/geoviews/refs/heads/main/doc/_static/logo_stacked.png" width="200"/><br>
 
 -----------------
 


### PR DESCRIPTION
Noticed it wasn't shown on PyPI