### PR TITLE
fix: Add save button back for tiles

### DIFF
--- a/geoviews/plotting/bokeh/__init__.py
+++ b/geoviews/plotting/bokeh/__init__.py
@@ -2,7 +2,7 @@ import copy
 
 import numpy as np
 import param
-from bokeh.models import BBoxTileSource, QUADKEYTileSource, SaveTool, WMTSTileSource
+from bokeh.models import BBoxTileSource, QUADKEYTileSource, WMTSTileSource
 from cartopy.crs import GOOGLE_MERCATOR
 from holoviews import NdOverlay, Overlay, Store
 from holoviews.core import util
@@ -145,9 +145,6 @@ class TilePlot(GeoPlot):
         level = properties.pop('level', 'underlay')
         renderer = plot.add_tile(tile_source, level=level)
         renderer.alpha = properties.get('alpha', 1)
-
-        # Remove save tool
-        plot.tools = [t for t in plot.tools if not isinstance(t, SaveTool)]
         return renderer, tile_source
 
 


### PR DESCRIPTION
Fixes #824

``` python
import geoviews as gv

gv.extension("bokeh")
gv.tile_sources.OSM().opts(title='Geoviews', tools = ['save'])

```

<img width="1017" height="677" alt="image" src="https://github.com/user-attachments/assets/40d19877-697f-4de3-a1c5-7d41fef360a6" />

<img width="450" height="450" alt="bokeh_plot" src="https://github.com/user-attachments/assets/9764cbf4-7fb0-471f-a609-72c3d030c4a5" />
