### PR TITLE
ci: Add retry option to download data to avoid failures

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -36,8 +36,6 @@ jobs:
     needs: [pixi_lock]
     runs-on: "macos-latest"
     timeout-minutes: 180
-    outputs:
-      tag: ${{ steps.vars.outputs.tag }}
     steps:
       - uses: holoviz-dev/holoviz_tasks/pixi_install@v0
         with:

--- a/scripts/download_data.py
+++ b/scripts/download_data.py
@@ -1,13 +1,27 @@
+import sys
+import time
 from contextlib import suppress
 from pathlib import Path
 
 BASE_PATH = Path(__file__).resolve().parents[1]
 
 
+def retry(func, *args, **kwargs):
+    for i in range(5):
+        try:
+            return func(*args, **kwargs)
+        except Exception as e:
+            wait = 10 * 2**i
+            print(f"Attempt {i + 1} failed: {e}. Retrying in {wait}s...", file=sys.stderr)
+            time.sleep(wait)
+    return func(*args, **kwargs)
+
+
 with suppress(ImportError):
     import pyct.cmd
 
-    pyct.cmd.fetch_data(
+    retry(
+        pyct.cmd.fetch_data,
         name="data",
         path=str(BASE_PATH / "examples"),
         datasets="datasets.yml",
@@ -17,23 +31,26 @@ with suppress(ImportError):
 with suppress(ImportError):
     import geodatasets as gds
 
-    gds.get_path("geoda airbnb")
-    gds.get_path("nybb")
+    retry(gds.get_path, "geoda airbnb")
+    retry(gds.get_path, "nybb")
 
 
 with suppress(ImportError):
-    import cftime  # noqa: F401
     import pooch  # noqa: F401
     import scipy  # noqa: F401
     import xarray as xr
 
-    xr.tutorial.open_dataset("air_temperature")
-    xr.tutorial.open_dataset("rasm")
+    retry(xr.tutorial.open_dataset, "air_temperature")
+    retry(xr.tutorial.open_dataset, "rasm", decode_times=False)
 
 with suppress(ImportError):
     from cartopy.feature import shapereader
 
-    shapereader.natural_earth(name="coastline")
-    shapereader.natural_earth(name="land")
-    shapereader.natural_earth(name="ocean")
-    shapereader.natural_earth(category="cultural", name="admin_0_boundary_lines_land")
+    retry(shapereader.natural_earth, name="coastline")
+    retry(shapereader.natural_earth, name="land")
+    retry(shapereader.natural_earth, name="ocean")
+    retry(
+        shapereader.natural_earth,
+        category="cultural",
+        name="admin_0_boundary_lines_land",
+    )


### PR DESCRIPTION
## Description

<!--
Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme

- Summarize the change and which issue is fixed.
- Include relevant motivation and context.
- Add visuals when possible, e.g. before/after screenshots with full code snippets.
-->

Github (used to download data) seems more and more flaky when downloading data. This adds a simple retry step, so we don't have to wait for CI to finish to rerun.

Same thing as done in https://github.com/holoviz/holoviews/pull/6841

## How Has This Been Tested?

CI
