### PR TITLE
Resolve custom-labelled dimensions by name in GeoPandasInterface

### DIFF
--- a/geoviews/data/geopandas.py
+++ b/geoviews/data/geopandas.py
@@ -13,7 +13,7 @@ from holoviews.core.data import (
 )
 from holoviews.core.data.interface import DataError
 from holoviews.core.data.spatialpandas import get_value_array
-from holoviews.core.dimension import dimension_name
+from holoviews.core.dimension import Dimension, dimension_name
 from holoviews.core.util import isscalar, unique_array, unique_iterator
 from holoviews.element import Path
 
@@ -274,11 +274,27 @@ class GeoPandasInterface(PandasAPI, MultiInterface):
             return float
 
     @classmethod
+    def _resolve_dimension(cls, dataset, dim):
+        """
+        Resolves a dimension spec to a Dimension of the dataset.
+
+        A Dimension built from a string spec (e.g. by a ``dim('name')``
+        expression) carries the name as its label, and Dimension equality
+        compares labels, so it would not match a dimension with a custom
+        label. Fall back to looking up the name, which matches both names
+        and labels.
+        """
+        resolved = dataset.get_dimension(dim)
+        if resolved is None and isinstance(dim, Dimension):
+            resolved = dataset.get_dimension(dim.name)
+        return resolved
+
+    @classmethod
     def isscalar(cls, dataset, dim, per_geom=False):
         """
         Tests if dimension is scalar in each subpath.
         """
-        dim = dataset.get_dimension(dim)
+        dim = cls._resolve_dimension(dataset, dim)
         geom_dims = cls.geom_dims(dataset)
         if dim in geom_dims:
             return False
@@ -286,12 +302,11 @@ class GeoPandasInterface(PandasAPI, MultiInterface):
             return all(
                 isscalar(v) or len(list(unique_array(v))) == 1 for v in dataset.data[dim.name]
             )
-        dim = dataset.get_dimension(dim)
         return len(dataset.data[dim.name].unique()) == 1
 
     @classmethod
     def range(cls, dataset, dim):
-        dim = dataset.get_dimension(dim)
+        dim = cls._resolve_dimension(dataset, dim)
         geom_dims = cls.geom_dims(dataset)
         if dim in geom_dims:
             col = cls.geo_column(dataset.data)
@@ -374,7 +389,7 @@ class GeoPandasInterface(PandasAPI, MultiInterface):
 
     @classmethod
     def values(cls, dataset, dimension, expanded=True, flat=True, compute=True, keep_index=False):
-        dimension = dataset.get_dimension(dimension)
+        dimension = cls._resolve_dimension(dataset, dimension)
         geom_dims = dataset.interface.geom_dims(dataset)
         data = dataset.data
         isgeom = dimension in geom_dims

--- a/geoviews/tests/data/test_geopandas.py
+++ b/geoviews/tests/data/test_geopandas.py
@@ -259,3 +259,24 @@ class GeoPandasInterfaceTest(GeomInterfaceTest, GeomTests, RoundTripTests):
         )
         gdf = geopandas.GeoDataFrame(df, geometry=geopandas.points_from_xy(df.x, df.y))
         render(Points(gdf))
+
+    def test_geopandas_vdim_with_custom_label_resolved_by_name(self):
+        # Fix for https://github.com/holoviz/geoviews/issues/840
+        # A dim() expression carries a Dimension whose label is the column
+        # name, which must still resolve against a vdim with a custom label.
+        from holoviews import dim
+
+        gdf = geopandas.GeoDataFrame(
+            {"status": ["safe", "endangered", "safe"]},
+            geometry=geopandas.points_from_xy([0, 1, 2], [0, 1, 2]),
+        )
+        points = Points(gdf, vdims=[("status", "Conservation Status")])
+        probe = dim("status").dimension
+        assert self.interface.isscalar(points, probe, per_geom=True)
+        assert_data_equal(
+            self.interface.values(points, probe),
+            np.array(["safe", "endangered", "safe"], dtype=object),
+        )
+        assert self.interface.range(points, probe) == ("endangered", "safe")
+        color = dim("status").categorize({"safe": "green", "endangered": "red"})
+        render(points.opts(color=color))


### PR DESCRIPTION
Fixes #840.

A `dim('status')` expression builds a `Dimension` whose label is the column name. `Dimension.__eq__` compares labels, so when the element declares that dimension with a custom label — `vdims=[('status', 'Conservation Status')]` — `dataset.get_dimension(dim)` returns `None`, and `GeoPandasInterface.isscalar` crashes with `AttributeError: 'NoneType' object has no attribute 'name'` during bokeh range computation. `values` and `range` fail the same way with the same probe.

This adds a `_resolve_dimension` helper that falls back to looking the dimension up by name — the string lookup path already matches both names and labels via its `name_map` — and uses it in `isscalar`, `range` and `values`. Also drops a leftover duplicate `get_dimension` call in `isscalar`.

The regression test covers the three interface methods plus the render path from the issue.

```python
gdf = gpd.GeoDataFrame({'status': ['safe', 'endangered', 'safe'],
                        'geometry': [Point(0,0), Point(1,1), Point(2,2)]}, crs='EPSG:4326')
points = gv.Points(gdf, vdims=[('status', 'Conservation Status')])
points.opts(color=dim('status').categorize({'safe': 'green', 'endangered': 'red'}))
hv.render(points)  # AttributeError before, renders after
```
