### PR TITLE
fix: default facecolor='none' for line-type Feature elements

### DIFF
--- a/geoviews/plotting/mpl/__init__.py
+++ b/geoviews/plotting/mpl/__init__.py
@@ -470,6 +470,18 @@ class FeaturePlot(GeoPlot):
         else:
             feature = copy.copy(element.data)
             feature.scale = self.scale
+        # Line features need facecolor='none'; the Collection default (C0/blue) fills open paths.
+        if (
+            'facecolor' not in style
+            and 'color' not in style
+            and 'facecolor' not in feature.kwargs
+            and 'color' not in feature.kwargs
+        ):
+            first_geom = next(iter(feature.geometries()), None)
+            if first_geom is not None and first_geom.geom_type in (
+                'LineString', 'MultiLineString', 'LinearRing'
+            ):
+                style['facecolor'] = 'none'
         return (feature,), style, {}
 
     def init_artists(self, ax, plot_args, plot_kwargs):

--- a/geoviews/tests/plotting/mpl/test_plot.py
+++ b/geoviews/tests/plotting/mpl/test_plot.py
@@ -1,3 +1,5 @@
+import cartopy.crs as ccrs
+import cartopy.feature as cf
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
@@ -5,7 +7,7 @@ import pyviz_comms as comms
 from param import concrete_descendents
 from shapely.geometry import MultiPolygon, Polygon
 
-from geoviews import Polygons, Store
+from geoviews import Feature, Polygons, Store
 from geoviews.plotting.mpl import ElementPlot
 
 mpl_renderer = Store.renderers['matplotlib']
@@ -81,3 +83,12 @@ class TestMPLPlot:
         )
 
         assert len(array) == total_subpolygons
+
+
+def test_feature_line_geometry_facecolor_default():
+    graticules = cf.NaturalEarthFeature(category="physical", name="graticules_30", scale="110m")
+    feature = Feature(graticules).opts(projection=ccrs.Orthographic())
+
+    plot = mpl_renderer.get_plot(feature)
+    artist = plot.handles['artist']
+    assert len(artist.get_facecolor()) == 0

--- a/geoviews/tests/plotting/mpl/test_plot.py
+++ b/geoviews/tests/plotting/mpl/test_plot.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 import pyviz_comms as comms
 from param import concrete_descendents
-from shapely.geometry import MultiPolygon, Polygon
+from shapely.geometry import LineString, MultiPolygon, Polygon
 
 from geoviews import Feature, Polygons, Store
 from geoviews.plotting.mpl import ElementPlot
@@ -86,8 +86,13 @@ class TestMPLPlot:
 
 
 def test_feature_line_geometry_facecolor_default():
-    graticules = cf.NaturalEarthFeature(category="physical", name="graticules_30", scale="110m")
-    feature = Feature(graticules).opts(projection=ccrs.Orthographic())
+    # test for https://github.com/holoviz/geoviews/issues/845
+
+    class _LineFeature(cf.Feature):
+        def geometries(self):
+            yield LineString([(0, 0), (1, 1)])
+
+    feature = Feature(_LineFeature(ccrs.PlateCarree())).opts(projection=ccrs.Orthographic())
 
     plot = mpl_renderer.get_plot(feature)
     artist = plot.handles['artist']

--- a/pixi.toml
+++ b/pixi.toml
@@ -211,7 +211,7 @@ test-example = 'pytest -n logical --dist loadscope --nbval-lax examples'
 nbval = "*"
 
 [feature.test-ui.dependencies]
-playwright = "!=1.61.0" # until python-playwright have a release
+playwright = "*"
 pytest-playwright = "*"
 
 [feature.test-ui.tasks]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,4 +215,8 @@ filterwarnings = [
     "ignore:numpy.ndarray size changed, may indicate binary incompatibility:RuntimeWarning", # https://github.com/pydata/xarray/issues/7259
     # 2025-04
     "ignore:The 'shapely.geos' module is deprecated, and will be removed in a future version:DeprecationWarning", # https://github.com/geopandas/geopandas/pull/3453
+    # 2026-06
+    "ignore:Setting the shape on a NumPy array has been deprecated in NumPy 2.5:DeprecationWarning:cartopy.img_transform",
+    "ignore:Setting the shape on a NumPy array has been deprecated in NumPy 2.5:DeprecationWarning:scipy.io._netcdf",
+    "ignore:Setting the shape on a NumPy array has been deprecated in NumPy 2.5:DeprecationWarning:rioxarray._io"
 ]

--- a/scripts/download_data.py
+++ b/scripts/download_data.py
@@ -54,3 +54,8 @@ with suppress(ImportError):
         category="cultural",
         name="admin_0_boundary_lines_land",
     )
+    retry(
+        shapereader.natural_earth,
+        category="physical",
+        name="graticules_30",
+    )

--- a/scripts/download_data.py
+++ b/scripts/download_data.py
@@ -54,8 +54,3 @@ with suppress(ImportError):
         category="cultural",
         name="admin_0_boundary_lines_land",
     )
-    retry(
-        shapereader.natural_earth,
-        category="physical",
-        name="graticules_30",
-    )


### PR DESCRIPTION
<!-- Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme -->

## Description
<!-- Summarize the change and which issue is fixed. Be sure to include relevant motivation and context. Describe the tests run to verify these changes and how to reproduce them (copy-pastable minimal, reproducible example). Include visuals when possible (e.g. before/after screenshots). -->

Fixes #845 

``` python
import cartopy.crs as ccrs
import cartopy.feature as cf
import geoviews as gv
gv.extension("matplotlib")


graticules = cf.NaturalEarthFeature(category="physical", name="graticules_30", scale="50m")
gv.Feature(graticules).opts(projection=ccrs.Orthographic())
```


Before:
<img width="339" height="230" alt="image" src="https://github.com/user-attachments/assets/5636ad5d-6801-4663-b667-850ea2c97dc3" />

After:

<img width="277" height="209" alt="image" src="https://github.com/user-attachments/assets/7c981864-2359-4318-8b57-1aea93e96b7d" />

Also fixing CI

## AI Disclosure
<!-- Delete this section if AI was not used, else specify the tool/model (e.g. Cursor + Sonnet 4.6, Claude Code + Opus 4.6, ChatGPT) and briefly describe how it was used. Failure to disclose AI usage may result in a ban. -->

Tool & Model: claude-code:claude-sonnet-4-6
Usage: Asked to make a reproducer in GeoViews and suggest a fix.

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.


## Checklist
<!-- Remove the non relevant items. -->

- [x] Tests added and are passing
