### PR TITLE
fix mpl 3.11

### DIFF
--- a/geoviews/plotting/mpl/__init__.py
+++ b/geoviews/plotting/mpl/__init__.py
@@ -74,7 +74,7 @@ from ...operation import (
     project_vectorfield,
     project_windbarbs,
 )
-from ...util import geo_mesh, poly_types
+from ...util import MPL_GE_3_11_0, geo_mesh, poly_types
 from ..plot import ProjectionPlot
 from .chart import WindBarbsPlot
 
@@ -133,6 +133,10 @@ class GeoOverlayPlot(ProjectionPlot, HvOverlayPlot):
             axis.grid()
         if self.global_extent:
             axis.set_global()
+        if gridlabels and MPL_GE_3_11_0:
+            # matplotlib 3.11 (#850): freeze the title auto-position so it
+            # stays finite when the native axis is hidden (see GeoPlot).
+            axis._autotitlepos = False
         return ret
 
 
@@ -240,6 +244,14 @@ class GeoPlot(ProjectionPlot, ElementPlot):
 
         if self.global_extent:
             axis.set_global()
+        if gridlabels and MPL_GE_3_11_0:
+            # matplotlib 3.11 (#850): with the native x/y axis hidden for
+            # PlateCarree/Mercator, Axes._update_title_position computes a
+            # non-finite (inf) title position. That propagates NaN through
+            # Axes.get_tightbbox into the layout figure sizing and raises
+            # "figure size must be positive finite". Freezing the title
+            # auto-position keeps it at the finite default location.
+            axis._autotitlepos = False
         return ret
 
     def get_data(self, element, ranges, style):

--- a/geoviews/tests/plotting/mpl/test_plot.py
+++ b/geoviews/tests/plotting/mpl/test_plot.py
@@ -103,3 +103,29 @@ def test_feature_line_geometry_facecolor_default():
     plot = mpl_renderer.get_plot(feature)
     artist = plot.handles["artist"]
     assert len(artist.get_facecolor()) == 0
+
+
+@pytest.mark.parametrize("projection", [ccrs.PlateCarree(), ccrs.Mercator()])
+def test_gridlabel_projection_layout_finite_figure_size(projection):
+    """Test for https://github.com/holoviz/geoviews/issues/850.
+
+    PlateCarree and Mercator hide the native matplotlib axis and use cartopy
+    gridliner labels instead. On matplotlib 3.11 Axes._update_title_position
+    then computed a non-finite title position for the hidden-axis GeoAxes,
+    which propagated NaN through get_tightbbox into the layout figure size and
+    raised "figure size must be positive finite". Rendering a titled layout
+    must keep the figure size and every title position finite.
+    """
+    poly = {"Longitude": [-170, 170, 170, -170], "Latitude": [-80, -80, 80, 80], "value": 1}
+    left = gv.Polygons([poly], vdims="value").opts(
+        projection=projection, title="left", colorbar=True
+    )
+    right = gv.Polygons([poly], vdims="value").opts(
+        projection=ccrs.Robinson(), title="right", colorbar=True
+    )
+
+    fig = mpl_renderer.get_plot(left + right).state
+
+    assert np.isfinite(fig.get_size_inches()).all()
+    for ax in fig.axes:
+        assert np.isfinite(ax.title.get_position()[1])

--- a/geoviews/util.py
+++ b/geoviews/util.py
@@ -1,6 +1,7 @@
 from contextlib import suppress
 
 import cartopy
+import matplotlib as mpl
 import numpy as np
 import shapely
 import shapely.geometry as sgeom
@@ -31,6 +32,8 @@ poly_types = (MultiPolygon, Polygon, LinearRing)
 SHAPELY_VERSION = Version(shapely.__version__).release
 SHAPELY_GE_2_0_0 = SHAPELY_VERSION >= (2, 0, 0)
 CARTOPY_VERSION = Version(cartopy.__version__).release
+MPL_VERSION = Version(mpl.__version__).release
+MPL_GE_3_11_0 = MPL_VERSION >= (3, 11, 0)
 
 
 def wrap_lons(lons, base, period):


### PR DESCRIPTION
<!-- Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme -->

## Description

Fixes #850

I fixed a crash on matplotlib 3.11 where a `PlateCarree` or `Mercator` plot (also the default projection when `features=[...]` is passed) rendered blank on its own and raised `ValueError: figure size must be positive finite not [ 8. nan]` inside a layout. For these two projections GeoViews hides the native x/y axis and draws cartopy gridliner labels instead, and on matplotlib 3.11 `Axes._update_title_position` computes a non-finite title `y` for such a hidden-axis `GeoAxes`, which then propagates through `Axes.get_tightbbox` into the HoloViews layout sizing and makes the figure size `NaN`. I freeze the title auto-position with `axis._autotitlepos = False` in the gridlabels path, gated on matplotlib >= 3.11 through a new `MPL_GE_3_11_0` flag in `geoviews.util`, so the title keeps its finite default location and the earlier behavior is restored. Other projections, matplotlib < 3.11, and the bokeh backend were never affected.

How to test:

```python
import numpy as np, cartopy.crs as ccrs
import geopandas as gpd, geoviews as gv, hvplot.pandas  # noqa
from shapely.geometry import Polygon

gv.extension('matplotlib')
lon = np.linspace(-170, 170, 11); lat = np.linspace(-80, 80, 6)
polys, vals = [], []
for i in range(len(lat) - 1):
    for j in range(len(lon) - 1):
        polys.append(Polygon([(lon[j], lat[i]), (lon[j+1], lat[i]),
                              (lon[j+1], lat[i+1]), (lon[j], lat[i+1])]))
        vals.append(i * 2 + j)
gdf = gpd.GeoDataFrame({'value': np.array(vals)}, geometry=polys, crs='EPSG:4326')
plot = lambda **kw: gdf.hvplot.polygons(color='value', cmap='viridis', **kw)

plot(features=['coastline'])
(plot(projection=ccrs.PlateCarree(), title='PlateCarree')
 + plot(projection=ccrs.Robinson(), title='Robinson'))
```


## AI Disclosure
<!-- Delete this section if AI was not used, else specify the tool/model (e.g. Cursor + Sonnet 4.6, Claude Code + Opus 4.6, ChatGPT) and briefly describe how it was used. Failure to disclose AI usage may result in a ban. -->

Tool & Model:
Usage:

- [x] I have tested all AI-generated content in my PR.
- [x] I take responsibility for all AI-generated content in my PR.


## Checklist
<!-- Remove the non relevant items. -->

- [x] Tests added and are passing
- [x] Added documentation
